### PR TITLE
Member 엔티티 및 Repository 추가

### DIFF
--- a/database/initdb.d/create_table.sql
+++ b/database/initdb.d/create_table.sql
@@ -1,17 +1,34 @@
-﻿CREATE TABLE `wastes`
+﻿CREATE TABLE `members`
 (
     `id`             bigint AUTO_INCREMENT NOT NULL,
-    `title`          varchar(255)          NOT NULL,
-    `content`        text                  NOT NULL,
-    `waste_price`     integer               NOT NULL,
-    `like_count`      integer               NOT NULL,
-    `view_count`      integer               NOT NULL,
-    `file_name`       varchar(255)          NULL,
-    `waste_category`  varchar(255)          NOT NULL,
-    `waste_status`    varchar(255)          NOT NULL,
-    `sell_status`     varchar(255)          NOT NULL,
-    `address`        json                  NOT NULL,
-    `created_at`     datetime              NOT NULL,
+    `email`          varchar(255) NOT NULL,
+    `rating`         double       NOT NULL,
+    `nickname`       varchar(255) NOT NULL,
+    `address`        json,
+    `file_name`      varchar(255),
+    `login_type`     varchar(255) NOT NULL,
+    `user_role`      varchar(255) NOT NULL,
+    `account_status` varchar(255) NOT NULL,
+    `created_at`     datetime     NOT NULL,
+    `modified_at`    datetime,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='멤버';
+
+CREATE TABLE `wastes`
+(
+    `id`             bigint AUTO_INCREMENT NOT NULL,
+    `title`          varchar(255) NOT NULL,
+    `content`        text         NOT NULL,
+    `waste_price`    integer      NOT NULL,
+    `like_count`     integer      NOT NULL,
+    `view_count`     integer      NOT NULL,
+    `file_name`      varchar(255),
+    `waste_category` varchar(255) NOT NULL,
+    `waste_status`   varchar(255) NOT NULL,
+    `sell_status`    varchar(255) NOT NULL,
+    `address`        json         NOT NULL,
+    `created_at`     datetime     NOT NULL,
     `modified_at`    datetime,
     `transaction_at` datetime,
     PRIMARY KEY (`id`)

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -1,2 +1,6 @@
+insert into members(email, rating, nickname, address, file_name, login_type, user_role, account_status, created_at, modified_at) values
+('abc@never.com', 10, 'abc', json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'), 'test.png', 'GOOGLE', 'USER', 'ACTIVE', now(), null);
+
+
 insert into wastes(title, content, waste_price, like_count, view_count, file_name, waste_category, waste_status, sell_status, address, created_at, modified_at, transaction_at) values
 ('title', 'content', 0, 0, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING', json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'), now(), null, null);

--- a/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
+++ b/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
@@ -2,7 +2,6 @@ package freshtrash.freshtrashbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class FreshTrashBackendApplication {
@@ -10,5 +9,4 @@ public class FreshTrashBackendApplication {
     public static void main(String[] args) {
         SpringApplication.run(FreshTrashBackendApplication.class, args);
     }
-
 }

--- a/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
+++ b/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
@@ -2,8 +2,10 @@ package freshtrash.freshtrashbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class FreshTrashBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
+++ b/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class FreshTrashBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
@@ -6,7 +6,10 @@ import freshtrash.freshtrashbackend.service.WasteServiceInterface;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Address.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Address.java
@@ -1,11 +1,10 @@
 package freshtrash.freshtrashbackend.entity;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class Address {
     private String zipcode;
     private String state;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -1,28 +1,28 @@
 package freshtrash.freshtrashbackend.entity;
 
+import freshtrash.freshtrashbackend.entity.audit.AuditingAt;
 import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
 import freshtrash.freshtrashbackend.entity.constants.LoginType;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 import org.springframework.data.domain.Persistable;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="members")
+@Table(name = "members")
 @Getter
-@Setter
-@ToString
-@EntityListeners(AuditingEntityListener.class)
-@EqualsAndHashCode(of = "id")
-public class Member implements Persistable<Long> {
+@ToString(callSuper = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@TypeDef(name = "json", typeClass = JsonType.class)
+public class Member extends AuditingAt implements Persistable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @Column(nullable = false)
@@ -34,7 +34,8 @@ public class Member implements Persistable<Long> {
     @Column(nullable = false)
     private String nickname;
 
-    @Embedded
+    @Type(type = "json")
+    @Column(columnDefinition = "longtext")
     private Address address;
 
     @Column
@@ -52,13 +53,16 @@ public class Member implements Persistable<Long> {
     @Column(nullable = false)
     private AccountStatus accountStatus;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime modifiedAt;
-
-    public Member(Long id, String email, double rating, String nickname, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus, LocalDateTime createdAt, LocalDateTime modifiedAt, Address address) {
+    public Member(
+            Long id,
+            String email,
+            double rating,
+            String nickname,
+            String fileName,
+            LoginType loginType,
+            UserRole userRole,
+            AccountStatus accountStatus,
+            Address address) {
         this.id = id;
         this.email = email;
         this.rating = rating;
@@ -67,8 +71,6 @@ public class Member implements Persistable<Long> {
         this.loginType = loginType;
         this.userRole = userRole;
         this.accountStatus = accountStatus;
-        this.createdAt = createdAt;
-        this.modifiedAt = modifiedAt;
         this.address = address;
     }
 
@@ -82,4 +84,3 @@ public class Member implements Persistable<Long> {
         return id == null;
     }
 }
-

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
     private Long id;
 
     @Column

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -21,28 +21,31 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(nullable = false)
     private String email;
 
-    @Column
+    @Column(nullable = false)
     private double rating;
 
-    @Column
+    @Column(nullable = false)
     private String nickname;
+
+    @Embedded
+    private Address address;
 
     @Column
     private String fileName;
 
     @Enumerated(EnumType.STRING)
-    @Column
+    @Column(nullable = false)
     private LoginType loginType;
 
     @Enumerated(EnumType.STRING)
-    @Column
+    @Column(nullable = false)
     private UserRole userRole;
 
     @Enumerated(EnumType.STRING)
-    @Column
+    @Column(nullable = false)
     private AccountStatus accountStatus;
 
     @CreatedDate
@@ -50,9 +53,6 @@ public class Member {
 
     @LastModifiedDate
     private LocalDateTime modifiedAt;
-
-    @Embedded
-    private Address address;
 
     public Member(Long id, String email, double rating, String nickname, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus, LocalDateTime createdAt, LocalDateTime modifiedAt, Address address) {
         this.id = id;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name="members")
 @Getter
 @Setter

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @Setter
 @ToString
 @EntityListeners(AuditingEntityListener.class)
-public class Member {
+public class Member implements Persistable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -68,6 +69,16 @@ public class Member {
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
         this.address = address;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return id == null;
     }
 }
 

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -3,9 +3,7 @@ package freshtrash.freshtrashbackend.entity;
 import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
 import freshtrash.freshtrashbackend.entity.constants.LoginType;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -15,8 +13,9 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor
 @Table(name="members")
-@Builder
-@AllArgsConstructor
+@Getter
+@Setter
+@ToString
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -55,5 +54,19 @@ public class Member {
 
     @Embedded
     private Address address;
+
+    public Member(Long id, String email, double rating, String nickname, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus, LocalDateTime createdAt, LocalDateTime modifiedAt, Address address) {
+        this.id = id;
+        this.email = email;
+        this.rating = rating;
+        this.nickname = nickname;
+        this.fileName = fileName;
+        this.loginType = loginType;
+        this.userRole = userRole;
+        this.accountStatus = accountStatus;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.address = address;
+    }
 }
 

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 @Setter
 @ToString
 @EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
 public class Member implements Persistable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 public class Member {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor
-@Table(name="member")
+@Table(name="members")
 @Builder
 @AllArgsConstructor
 public class Member {

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -1,0 +1,59 @@
+package freshtrash.freshtrashbackend.entity;
+
+import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
+import freshtrash.freshtrashbackend.entity.constants.LoginType;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@Table(name="member")
+@Builder
+@AllArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id")
+    private Long id;
+
+    @Column
+    private String email;
+
+    @Column
+    private double rating;
+
+    @Column
+    private String nickname;
+
+    @Column
+    private String fileName;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private LoginType loginType;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private UserRole userRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private AccountStatus accountStatus;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    @Embedded
+    private Address address;
+}
+

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/AccountStatus.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/AccountStatus.java
@@ -1,0 +1,7 @@
+package freshtrash.freshtrashbackend.entity.constants;
+
+public enum AccountStatus {
+    ACTIVE,
+    INACTIVE,
+    BLOCK
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/LoginType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/LoginType.java
@@ -1,0 +1,8 @@
+package freshtrash.freshtrashbackend.entity.constants;
+
+public enum LoginType {
+    EMAIL,
+    KAKAO,
+    GOOGLE,
+    NAVER
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/UserRole.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/UserRole.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.entity.constants;
 
 public enum UserRole {
-    USER
+    USER,
+    ADMIN
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/UserRole.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/UserRole.java
@@ -1,0 +1,5 @@
+package freshtrash.freshtrashbackend.entity.constants;
+
+public enum UserRole {
+    USER
+}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
@@ -3,5 +3,4 @@ package freshtrash.freshtrashbackend.repository;
 import freshtrash.freshtrashbackend.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
-}
+public interface MemberRepository extends JpaRepository<Member, Long> {}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
1주차 스프린트 계획에 따라, 가람님과 함께 회원가입 및 회원탈퇴 기능을 분담했습니다. 이에 따라, 두 기능에서 공통적으로 사용되는 Member 엔티티와 Repository를 먼저 추가했습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
ERD를 기준으로 members 테이블에 해당하는 Member 엔티티의 필드를 추가했으며, `Address`필드는 `@Embeddable`어노테이션을 활용해 별도의 클래스로 분리했습니다. 또한, 코드의 가독성과 유지관리를 용이하게 하기 위해 constants 패키지 내에 enum 타입으로 정의된 `loginType`, `userRole`, `accountStatus` 필드를 별도의 상수 클래스로 분리했습니다.
![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/98696925/9cc0cf6d-4b20-4972-a741-ea4652cf6a0f)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
Member 엔티티에서 `@Table(name="member")`에서 `@Table(name="members")`로 변경

## Issue Tags
Closed: #2 
