### PR TITLE
파일 저장 서비스 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,4 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,maven,intellij+all,macos,windows
 .env
+**/imgs/

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.7.3'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
+++ b/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
@@ -2,7 +2,9 @@ package freshtrash.freshtrashbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class FreshTrashBackendApplication {
 

--- a/src/main/java/freshtrash/freshtrashbackend/dto/properties/LocalFileProperties.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/properties/LocalFileProperties.java
@@ -1,0 +1,13 @@
+package freshtrash.freshtrashbackend.dto.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * @param absolutePath 파일을 저장하는 경로
+ */
+@Validated
+@ConfigurationProperties(prefix = "local-file")
+public record LocalFileProperties(@NotBlank String absolutePath) {}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/WasteRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/WasteRequest.java
@@ -18,6 +18,6 @@ public record WasteRequest(
         @NotNull Integer wastePrice,
         @NotNull Address address) {
     public Waste toEntity(String fileName) {
-        return Waste.of(title, content, wastePrice, fileName, wasteCategory, wasteStatus, sellStatus, address);
+        return Waste.of(title, content, wastePrice, fileName, wasteCategory, wasteStatus, sellStatus, address.allBlank() ? null : address);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/ExceptionResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/ExceptionResponse.java
@@ -1,0 +1,23 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+import org.springframework.validation.BindingResult;
+
+import java.util.List;
+
+public record ExceptionResponse(String message, List<FieldErrorInfo> errors) {
+    public static ExceptionResponse of(String message) {
+        return new ExceptionResponse(message, null);
+    }
+
+    public static ExceptionResponse of(String message, List<FieldErrorInfo> errors) {
+        return new ExceptionResponse(message, errors);
+    }
+
+    public static ExceptionResponse fromBindingResult(String message, BindingResult bindingResult) {
+        return new ExceptionResponse(
+                message,
+                bindingResult.getFieldErrors().stream()
+                        .map(fieldError -> FieldErrorInfo.of(fieldError.getField(), fieldError.getDefaultMessage()))
+                        .toList());
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/FieldErrorInfo.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/FieldErrorInfo.java
@@ -1,0 +1,7 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+public record FieldErrorInfo(String field, String message) {
+    public static FieldErrorInfo of(String field, String message) {
+        return new FieldErrorInfo(field, message);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Address.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Address.java
@@ -2,6 +2,7 @@ package freshtrash.freshtrashbackend.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 @Getter
 @NoArgsConstructor
@@ -22,5 +23,9 @@ public class Address {
 
     public static Address of(String zipcode, String state, String city, String district, String detail) {
         return new Address(zipcode, state, city, district, detail);
+    }
+
+    public boolean allBlank() {
+        return StringUtils.isAllBlank(this.zipcode, this.state, this.city, this.district, this.detail);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package freshtrash.freshtrashbackend.exception;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import freshtrash.freshtrashbackend.dto.response.ExceptionResponse;
+import freshtrash.freshtrashbackend.dto.response.FieldErrorInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * bindingResult 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> resolveException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException is occurred.", e);
+        String message = "Validation failed for argument in "
+                + e.getParameter().getExecutable().getName();
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ExceptionResponse.fromBindingResult(message, e.getBindingResult()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ExceptionResponse> resolveException(DataIntegrityViolationException e) {
+        log.error("DataIntegrityViolationException is occurred.", e);
+        return ResponseEntity.status(BAD_REQUEST).body(ExceptionResponse.of(e.getMessage()));
+    }
+
+    /**
+     * Request 요청 처리시 Enum 클래스와 같은 타입의 데이터 바인딩에 문제가 발생했을 경우
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionResponse> resolveException(InvalidFormatException e) {
+        log.error("InvalidFormatException is occurred.", e);
+        FieldErrorInfo fieldErrorInfo = FieldErrorInfo.of(
+                e.getTargetType().getName(),
+                String.format("%s가 입력되었습니다.", e.getValue().toString()));
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ExceptionResponse.of(e.getOriginalMessage(), List.of(fieldErrorInfo)));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> resolveException(Exception e) {
+        log.error("Exception is occurred.", e);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ExceptionResponse.of(e.getMessage()));
+    }
+
+    @ExceptionHandler(value = CustomException.class)
+    public ResponseEntity<ExceptionResponse> resolveException(CustomException e) {
+        log.error("CustomException is occurred.", e);
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+                .body(ExceptionResponse.of(e.getErrorCode().getMessage()));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/WasteException.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/WasteException.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.exception;
+
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class WasteException extends CustomException {
+    public WasteException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public WasteException(ErrorCode errorCode, Exception causeException) {
+        super(errorCode, causeException);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -8,7 +8,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     // File
-    INVALID_FIlE_NAME(HttpStatus.BAD_REQUEST, "파일 형식이 잘못되었습니다.");
+    INVALID_FIlE_NAME(HttpStatus.BAD_REQUEST, "파일 형식이 잘못되었습니다."),
+    FILE_CANT_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
+    FILE_CANT_SAVE(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 저장 할 수 없습니다. 파일 경로를 다시 확인해주세요."),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+    FAILED_DOWNLOAD_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "파일 다운로드에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
     FILE_CANT_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
     FILE_CANT_SAVE(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 저장 할 수 없습니다. 파일 경로를 다시 확인해주세요."),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
-    FAILED_DOWNLOAD_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "파일 다운로드에 실패했습니다.");
+    FAILED_DOWNLOAD_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "파일 다운로드에 실패했습니다."),
+    // Waste
+    EMPTY_ADDRESS(HttpStatus.BAD_REQUEST, "주소가 입력되지 않았습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/service/FileServiceInterface.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/FileServiceInterface.java
@@ -1,0 +1,12 @@
+package freshtrash.freshtrashbackend.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 로컬(개발) 환경과 운영 환경을 구분하여 구현합니다.
+ */
+public interface FileServiceInterface {
+    void uploadFile(MultipartFile file, String fileName);
+
+    void deleteFileIfExists(String fileName);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/impl/LocalFileService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/impl/LocalFileService.java
@@ -1,0 +1,46 @@
+package freshtrash.freshtrashbackend.service.impl;
+
+import freshtrash.freshtrashbackend.dto.properties.LocalFileProperties;
+import freshtrash.freshtrashbackend.exception.FileException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.service.FileServiceInterface;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class LocalFileService implements FileServiceInterface {
+    private final LocalFileProperties localFileProperties;
+
+    @Override
+    public void uploadFile(MultipartFile file, String fileName) {
+        try (FileOutputStream fos = new FileOutputStream(createFileInstance(fileName))) {
+            fos.write(file.getBytes());
+        } catch (IOException e) {
+            throw new FileException(ErrorCode.FILE_CANT_SAVE, e);
+        }
+    }
+
+    @Override
+    public void deleteFileIfExists(String fileName) {
+        File file = createFileInstance(fileName);
+        // 파일이 존재하지 않을 경우 예외 처리
+        if (file.exists()) {
+            // 파일을 정상적으로 삭제할 경우 true를 반환하며 false를 반환할 경우 예외 처리
+            if (!file.delete()) {
+                throw new FileException(ErrorCode.FILE_CANT_DELETE);
+            }
+        } else {
+            throw new FileException(ErrorCode.FILE_NOT_FOUND);
+        }
+    }
+
+    private File createFileInstance(String fileName) {
+        return new File(localFileProperties.absolutePath(), fileName);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/impl/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/impl/WasteService.java
@@ -3,6 +3,8 @@ package freshtrash.freshtrashbackend.service.impl;
 import freshtrash.freshtrashbackend.dto.WasteDto;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
 import freshtrash.freshtrashbackend.entity.Waste;
+import freshtrash.freshtrashbackend.exception.WasteException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.WasteRepository;
 import freshtrash.freshtrashbackend.service.FileServiceInterface;
 import freshtrash.freshtrashbackend.service.WasteServiceInterface;
@@ -11,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -22,10 +26,15 @@ public class WasteService implements WasteServiceInterface {
     @Override
     public WasteDto addWaste(MultipartFile imgFile, WasteRequest wasteRequest) {
         // TODO: 유저 정보 추가
+        // 주소가 입력되지 않았을 경우
+        if (Objects.isNull(wasteRequest.address())) throw new WasteException(ErrorCode.EMPTY_ADDRESS);
+
         String savedFileName = FileUtils.generateUniqueFileName(imgFile.getOriginalFilename());
-        Waste waste = wasteRepository.save(wasteRequest.toEntity(savedFileName));
+        Waste waste = wasteRequest.toEntity(savedFileName);
+
+        Waste savedWaste = wasteRepository.save(waste);
         // 이미지 파일 저장
         fileService.uploadFile(imgFile, savedFileName);
-        return WasteDto.fromEntity(waste);
+        return WasteDto.fromEntity(savedWaste);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/impl/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/impl/WasteService.java
@@ -4,6 +4,7 @@ import freshtrash.freshtrashbackend.dto.WasteDto;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
 import freshtrash.freshtrashbackend.entity.Waste;
 import freshtrash.freshtrashbackend.repository.WasteRepository;
+import freshtrash.freshtrashbackend.service.FileServiceInterface;
 import freshtrash.freshtrashbackend.service.WasteServiceInterface;
 import freshtrash.freshtrashbackend.utils.FileUtils;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +17,15 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class WasteService implements WasteServiceInterface {
     private final WasteRepository wasteRepository;
+    private final FileServiceInterface fileService;
 
     @Override
-    public WasteDto addWaste(MultipartFile modelFile, WasteRequest wasteRequest) {
+    public WasteDto addWaste(MultipartFile imgFile, WasteRequest wasteRequest) {
         // TODO: 유저 정보 추가
-        // TODO: 파일 저장 로직 추가
-        Waste waste = wasteRepository.save(
-                wasteRequest.toEntity(FileUtils.generateUniqueFileName(modelFile.getOriginalFilename())));
+        String savedFileName = FileUtils.generateUniqueFileName(imgFile.getOriginalFilename());
+        Waste waste = wasteRepository.save(wasteRequest.toEntity(savedFileName));
+        // 이미지 파일 저장
+        fileService.uploadFile(imgFile, savedFileName);
         return WasteDto.fromEntity(waste);
     }
 }

--- a/src/main/resources/application-file.yml
+++ b/src/main/resources/application-file.yml
@@ -1,0 +1,2 @@
+local-file:
+  absolute-path: ${LOCAL_FILE_ABS_PATH} # 파일 저장 경로

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
     group:
       local:
         - common
+        - file
       test:
 
 ---

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
         - common
         - file
       test:
+        - file
 
 ---
 

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -1,0 +1,29 @@
+package freshtrash.freshtrashbackend.Fixture;
+
+import freshtrash.freshtrashbackend.entity.Address;
+import freshtrash.freshtrashbackend.entity.Waste;
+import freshtrash.freshtrashbackend.entity.constants.SellStatus;
+import freshtrash.freshtrashbackend.entity.constants.WasteCategory;
+import freshtrash.freshtrashbackend.entity.constants.WasteStatus;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.charset.StandardCharsets;
+
+public class Fixture {
+    public static Waste createWaste() {
+        return Waste.of(
+                "title",
+                "content",
+                0,
+                "test.png",
+                WasteCategory.BEAUTY,
+                WasteStatus.BEST,
+                SellStatus.CLOSE,
+                Address.of("12345", "state", "city", "district", "detail"));
+    }
+
+    public static MockMultipartFile createMultipartFile(String content) {
+        String fileName = "test.png";
+        return new MockMultipartFile("modelFile", fileName, "text/plain", content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -1,0 +1,39 @@
+package freshtrash.freshtrashbackend.Fixture;
+
+import freshtrash.freshtrashbackend.dto.WasteDto;
+import freshtrash.freshtrashbackend.dto.request.WasteRequest;
+import freshtrash.freshtrashbackend.entity.Address;
+import freshtrash.freshtrashbackend.entity.constants.SellStatus;
+import freshtrash.freshtrashbackend.entity.constants.WasteCategory;
+import freshtrash.freshtrashbackend.entity.constants.WasteStatus;
+
+import java.time.LocalDateTime;
+
+public class FixtureDto {
+
+    public static WasteRequest createWasteRequest() {
+        return new WasteRequest(
+                "title",
+                "content",
+                WasteCategory.BEAUTY,
+                WasteStatus.BEST,
+                SellStatus.CLOSE,
+                0,
+                Address.of("12345", "state", "city", "district", "detail"));
+    }
+
+    public static WasteDto createWasteDto() {
+        return new WasteDto(
+                "title",
+                "content",
+                0,
+                0,
+                0,
+                "test.png",
+                WasteCategory.BEAUTY,
+                WasteStatus.BEST,
+                SellStatus.CLOSE,
+                Address.of("12345", "state", "city", "district", "detail"),
+                LocalDateTime.now());
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -11,6 +11,10 @@ import java.time.LocalDateTime;
 
 public class FixtureDto {
 
+    public static WasteRequest createWasteRequest(String title, String content, WasteCategory wasteCategory, WasteStatus wasteStatus, SellStatus sellStatus, Integer wastePrice, Address address) {
+        return new WasteRequest(title, content, wasteCategory, wasteStatus, sellStatus, wastePrice, address.allBlank() ? null : address);
+    }
+
     public static WasteRequest createWasteRequest() {
         return new WasteRequest(
                 "title",

--- a/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
@@ -1,0 +1,57 @@
+package freshtrash.freshtrashbackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.Fixture.FixtureDto;
+import freshtrash.freshtrashbackend.dto.WasteDto;
+import freshtrash.freshtrashbackend.dto.request.WasteRequest;
+import freshtrash.freshtrashbackend.service.impl.WasteService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WasteApi.class)
+class WasteApiTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private WasteService wasteService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("폐기물 등록")
+    @Test
+    void addWaste() throws Exception {
+        // given
+        MockMultipartFile imgFile = Fixture.createMultipartFile("test_image");
+        WasteRequest wasteRequest = FixtureDto.createWasteRequest();
+        WasteDto wasteDto = FixtureDto.createWasteDto();
+        given(wasteService.addWaste(any(MultipartFile.class), any(WasteRequest.class)))
+                .willReturn(wasteDto);
+        // when
+        mvc.perform(multipart(HttpMethod.POST, "/api/v1/wastes")
+                        .file("imgFile", imgFile.getBytes())
+                        .file(new MockMultipartFile(
+                                "wasteRequest", "", "application/json", objectMapper.writeValueAsBytes(wasteRequest)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("title"))
+                .andExpect(jsonPath("$.content").value("content"));
+        // then
+    }
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 폐기물, 경매, 프로필 이미지를 저장하기위한 서비스 로직을 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 파일을 저장, 삭제하는 로직을 구현했습니다.
    - 비용 문제를 고려하여 개발 환경에서는 로컬 경로에 파일을 저장하도록 반영했습니다.
- 파일 경로는 각 로컬 환경에서 프로젝트 디렉토리의 resources/imgs 를 기준으로 설정하였습니다. (e.g. /Users/joo/Desktop/fresh-trash-backend/src/main/resources/imgs)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 테스트 코드 작성
- 기존 폐기물 등록 비지니스 로직에서 파라미터명이 modelFile으로 되어있어 imgFile로 수정
- 파일 저장 경로 설정을 위해 application-file.yml 추가

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 3일 이내에 진행해 주세요.

## Issue Tags
- Closed: #7 
