### PR TITLE
Member와 Waste의 연관 관계 설정 및 방어 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.7.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/database/initdb.d/create_table.sql
+++ b/database/initdb.d/create_table.sql
@@ -21,6 +21,7 @@
 CREATE TABLE `wastes`
 (
     `id`             bigint AUTO_INCREMENT NOT NULL,
+    `member_id`      bigint                NOT NULL,
     `title`          varchar(255)          NOT NULL,
     `content`        text                  NOT NULL,
     `waste_price`    integer               NOT NULL,
@@ -34,7 +35,8 @@ CREATE TABLE `wastes`
     `created_at`     datetime              NOT NULL,
     `modified_at`    datetime,
     `transaction_at` datetime,
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    foreign key (`member_id`) references members (id) on delete cascade
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='폐기물';
 

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -5,8 +5,8 @@ values ('abc@never.com', '$2a$10$4mbVj4n1KeBmNsQCeXZpZujVo.cmXMdPIoDUQ1c1jkR87Ld
         'test.png', 'GOOGLE', 'USER', 'ACTIVE', now(), null);
 
 
-insert into wastes(title, content, waste_price, like_count, view_count, file_name, waste_category, waste_status,
+insert into wastes(member_id, title, content, waste_price, like_count, view_count, file_name, waste_category, waste_status,
                    sell_status, address, created_at, modified_at, transaction_at)
-values ('title', 'content', 0, 0, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING',
+values (1, 'title', 'content', 0, 0, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
         now(), null, null);

--- a/src/main/java/freshtrash/freshtrashbackend/dto/UserInfo.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/UserInfo.java
@@ -1,0 +1,14 @@
+package freshtrash.freshtrashbackend.dto;
+
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Address;
+import freshtrash.freshtrashbackend.entity.Member;
+
+public record UserInfo(String nickname, double rating, String fileName, Address address) {
+    public static UserInfo fromEntity(Member member) {
+        return new UserInfo(member.getNickname(), member.getRating(), member.getFileName(), member.getAddress());
+    }
+    public static UserInfo fromPrincipal(MemberPrincipal memberPrincipal) {
+        return new UserInfo(memberPrincipal.nickname(), memberPrincipal.rating(), memberPrincipal.fileName(), memberPrincipal.address());
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/WasteDto.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/WasteDto.java
@@ -1,6 +1,7 @@
 package freshtrash.freshtrashbackend.dto;
 
 import freshtrash.freshtrashbackend.dto.constants.SellType;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Address;
 import freshtrash.freshtrashbackend.entity.Waste;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
@@ -21,7 +22,8 @@ public record WasteDto(
         WasteStatus wasteStatus,
         SellStatus sellStatus,
         Address address,
-        LocalDateTime createdAt) {
+        LocalDateTime createdAt,
+        UserInfo userInfo) {
     public static WasteDto fromEntity(Waste waste) {
         return new WasteDto(
                 waste.getTitle(),
@@ -35,6 +37,24 @@ public record WasteDto(
                 waste.getWasteStatus(),
                 waste.getSellStatus(),
                 waste.getAddress(),
-                waste.getCreatedAt());
+                waste.getCreatedAt(),
+                UserInfo.fromEntity(waste.getMember()));
+    }
+
+    public static WasteDto fromEntity(Waste waste, MemberPrincipal memberPrincipal) {
+        return new WasteDto(
+                waste.getTitle(),
+                waste.getContent(),
+                waste.getWastePrice() == 0 ? SellType.SHARE : SellType.TRANSACTION,
+                waste.getWastePrice(),
+                waste.getLikeCount(),
+                waste.getViewCount(),
+                waste.getFileName(),
+                waste.getWasteCategory(),
+                waste.getWasteStatus(),
+                waste.getSellStatus(),
+                waste.getAddress(),
+                waste.getCreatedAt(),
+                UserInfo.fromPrincipal(memberPrincipal));
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/WasteRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/WasteRequest.java
@@ -17,7 +17,7 @@ public record WasteRequest(
         @NotNull SellStatus sellStatus,
         @NotNull Integer wastePrice,
         @NotNull Address address) {
-    public Waste toEntity(String fileName) {
+    public Waste toEntity(String fileName, Long memberId) {
         return Waste.of(
                 title,
                 content,
@@ -26,6 +26,7 @@ public record WasteRequest(
                 wasteCategory,
                 wasteStatus,
                 sellStatus,
-                address.allBlank() ? null : address);
+                address.allBlank() ? null : address,
+                memberId);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.dto.security;
 
+import freshtrash.freshtrashbackend.entity.Address;
 import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import org.springframework.security.core.GrantedAuthority;
@@ -10,17 +11,46 @@ import java.util.Collection;
 import java.util.Set;
 
 public record MemberPrincipal(
-        Long id, String email, String password, Collection<? extends GrantedAuthority> authorities, String nickname)
+        Long id,
+        String email,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String nickname,
+        double rating,
+        String fileName,
+        Address address)
         implements UserDetails {
 
-    public static MemberPrincipal of(Long id, String email, String password, String nickname, UserRole userRole) {
+    public static MemberPrincipal of(
+            Long id,
+            String email,
+            String password,
+            String nickname,
+            UserRole userRole,
+            double rating,
+            String fileName,
+            Address address) {
         return new MemberPrincipal(
-                id, email, password, Set.of(new SimpleGrantedAuthority(userRole.getName())), nickname);
+                id,
+                email,
+                password,
+                Set.of(new SimpleGrantedAuthority(userRole.getName())),
+                nickname,
+                rating,
+                fileName,
+                address);
     }
 
     public static MemberPrincipal fromEntity(Member member) {
         return MemberPrincipal.of(
-                member.getId(), member.getEmail(), member.getPassword(), member.getNickname(), member.getUserRole());
+                member.getId(),
+                member.getEmail(),
+                member.getPassword(),
+                member.getNickname(),
+                member.getUserRole(),
+                member.getRating(),
+                member.getFileName(),
+                member.getAddress());
     }
 
     public UserRole getUserRole() {

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -11,6 +11,11 @@ import org.hibernate.annotations.TypeDef;
 import org.springframework.data.domain.Persistable;
 
 import javax.persistence.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static javax.persistence.CascadeType.ALL;
+import static javax.persistence.FetchType.LAZY;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -55,6 +60,10 @@ public class Member extends AuditingAt implements Persistable<Long> {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AccountStatus accountStatus;
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "member", cascade = ALL, fetch = LAZY)
+    private Set<Waste> wastes = new LinkedHashSet<>();
 
     @PrePersist
     private void prePersist() {

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Waste.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Waste.java
@@ -14,6 +14,8 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import static javax.persistence.FetchType.LAZY;
+
 @Getter
 @ToString(callSuper = true)
 @Table(name = "wastes")
@@ -72,16 +74,23 @@ public class Waste extends AuditingAt implements Persistable<Long> {
     @Setter
     private LocalDateTime transactionAt;
 
+    @ToString.Exclude
+    @ManyToOne(optional = false, fetch = LAZY)
+    @JoinColumn(name = "memberId", insertable = false, updatable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private Long memberId;
+
     // TODO: waste_reviews와 연관 관계 설정
     // TODO: chat_room과 연관 관계 설정
     // TODO: transaction_logs와 연관 관계 설정
     // TODO: waste_likes와 연관 관계 설정
-    // TODO: members와 연관 관계 설정
 
     @PrePersist
     private void prePersist() {
-        this.likeCount = Objects.isNull(this.likeCount) ? 0 : this.likeCount;
-        this.viewCount = Objects.isNull(this.viewCount) ? 0 : this.viewCount;
+        this.likeCount = 0;
+        this.viewCount = 0;
     }
 
     private Waste(
@@ -92,7 +101,8 @@ public class Waste extends AuditingAt implements Persistable<Long> {
             WasteCategory wasteCategory,
             WasteStatus wasteStatus,
             SellStatus sellStatus,
-            Address address) {
+            Address address,
+            Long memberId) {
         this.title = title;
         this.content = content;
         this.wastePrice = wastePrice;
@@ -101,6 +111,7 @@ public class Waste extends AuditingAt implements Persistable<Long> {
         this.wasteStatus = wasteStatus;
         this.sellStatus = sellStatus;
         this.address = address;
+        this.memberId = memberId;
     }
 
     public static Waste of(
@@ -111,8 +122,9 @@ public class Waste extends AuditingAt implements Persistable<Long> {
             WasteCategory wasteCategory,
             WasteStatus wasteStatus,
             SellStatus sellStatus,
-            Address address) {
-        return new Waste(title, content, wastePrice, fileName, wasteCategory, wasteStatus, sellStatus, address);
+            Address address,
+            Long memberId) {
+        return new Waste(title, content, wastePrice, fileName, wasteCategory, wasteStatus, sellStatus, address, memberId);
     }
 
     @Override

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     // Waste
     EMPTY_ADDRESS(HttpStatus.BAD_REQUEST, "주소가 입력되지 않았습니다."),
     NOT_FOUND_WASTE(HttpStatus.NOT_FOUND, "폐기물 정보가 존재하지 않습니다."),
+    FORBIDDEN_WASTE(HttpStatus.FORBIDDEN, "폐기물에 대한 권한이 없습니다."),
 
     // Mail
     AUTH_CODE_UNMATCHED(HttpStatus.BAD_REQUEST, "잘못된 인증코드입니다."),

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface WasteRepository extends JpaRepository<Waste, Long> {
     @Query("select w.fileName from Waste w where w.id = ?1")
     Optional<String> findFileNameById(Long wasteId);
+
+    boolean existsByIdAndMember_Id(Long wasteId, Long memberId);
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -1,11 +1,11 @@
 package freshtrash.freshtrashbackend.Fixture;
 
 import freshtrash.freshtrashbackend.entity.Address;
+import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.entity.Waste;
-import freshtrash.freshtrashbackend.entity.constants.SellStatus;
-import freshtrash.freshtrashbackend.entity.constants.WasteCategory;
-import freshtrash.freshtrashbackend.entity.constants.WasteStatus;
+import freshtrash.freshtrashbackend.entity.constants.*;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
 
@@ -19,11 +19,30 @@ public class Fixture {
                 WasteCategory.BEAUTY,
                 WasteStatus.BEST,
                 SellStatus.CLOSE,
-                Address.of("12345", "state", "city", "district", "detail"));
+                createAddress(),
+                1L);
     }
 
     public static MockMultipartFile createMultipartFile(String content) {
         String fileName = "test.png";
         return new MockMultipartFile("modelFile", fileName, "text/plain", content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static Address createAddress() {
+        return Address.of("12345", "state", "city", "district", "detail");
+    }
+
+    public static Member createMember(
+            String email,
+            String password,
+            String nickname,
+            LoginType loginType,
+            UserRole userRole,
+            AccountStatus accountStatus) {
+        Member member = Member.signup(email, password, nickname, loginType, userRole, accountStatus);
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "fileName", "test.png");
+        ReflectionTestUtils.setField(member, "address", Fixture.createAddress());
+        return member;
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.Fixture;
 
+import freshtrash.freshtrashbackend.dto.UserInfo;
 import freshtrash.freshtrashbackend.dto.WasteDto;
 import freshtrash.freshtrashbackend.dto.constants.SellType;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
@@ -38,7 +39,7 @@ public class FixtureDto {
                 WasteStatus.BEST,
                 SellStatus.CLOSE,
                 0,
-                Address.of("12345", "state", "city", "district", "detail"));
+                Fixture.createAddress());
     }
 
     public static WasteDto createWasteDto() {
@@ -46,14 +47,15 @@ public class FixtureDto {
                 "title",
                 "content",
                 SellType.SHARE,
-                0,
-                0,
-                0,
+                1000,
+                2,
+                3,
                 "test.png",
                 WasteCategory.BEAUTY,
                 WasteStatus.BEST,
                 SellStatus.CLOSE,
                 Address.of("12345", "state", "city", "district", "detail"),
-                LocalDateTime.now());
+                LocalDateTime.now(),
+                new UserInfo("test", 4, "test.png", Fixture.createAddress()));
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
+++ b/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
@@ -1,11 +1,30 @@
 package freshtrash.freshtrashbackend.config;
 
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.entity.Member;
+import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
+import freshtrash.freshtrashbackend.entity.constants.LoginType;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.security.SecurityConfig;
 import freshtrash.freshtrashbackend.service.MemberService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
 @Import(SecurityConfig.class)
 public class TestSecurityConfig {
     @MockBean private MemberService memberService;
+
+    @BeforeTestMethod
+    void securitySetUp() {
+        String userEmail = "testUser@gmail.com";
+        given(memberService.getMemberEntityByEmail(eq(userEmail))).willReturn(createMember(userEmail));
+    }
+
+    private Member createMember(String email) {
+        return Fixture.createMember(email, "pw", "test", LoginType.EMAIL, UserRole.USER, AccountStatus.ACTIVE);
+    }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- Member는 여러 Waste를 가질 수 있으므로 Member와 Waste는 1:N 관계로 설정합니다. 또한 Waste의 수정/삭제는 작성자 또는 관리자만 가능하도록 방어 로직을 추가합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- Member와 Waste의 연관 관계(1:N) 설정했습니다.
- Waste 등록/수정 시 반환되는 DTO 객체에 유저 정보(닉네임, 평점, 프로필 이미지 파일명, 주소)를 추가했습니다.
    - MemberPrincipal에도 유저 정보(닉네임, 평점, 프로필 이미지 파일명, 주소)를 추가했습니다.
- Waste 수정/삭제 시 작성자 또는 관리자만 가능하도록 방어 로직을 추가했습니다.
- 유저 정보 추가에 따른 테스트 코드 수정

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- spring security의 TestImplementation을 추가했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #26 
