### PR TITLE
AccessToken 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,17 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    jjwtVersion = '0.12.5'
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.7.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -37,6 +42,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    //jwt
+    implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
 }
 
 tasks.named('test') {

--- a/src/main/java/freshtrash/freshtrashbackend/controller/SignInApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/SignInApi.java
@@ -1,0 +1,26 @@
+package freshtrash.freshtrashbackend.controller;
+
+import freshtrash.freshtrashbackend.dto.request.LoginRequest;
+import freshtrash.freshtrashbackend.dto.response.LoginResponse;
+import freshtrash.freshtrashbackend.service.SigInService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/signin")
+@RequiredArgsConstructor
+public class SignInApi {
+    private final SigInService signInService;
+
+    @PostMapping
+    public ResponseEntity<LoginResponse> signIn(@RequestBody @Valid LoginRequest loginRequest) {
+        LoginResponse loginResponse = signInService.signIn(loginRequest.email(), loginRequest.password());
+        return ResponseEntity.ok(loginResponse);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/properties/JwtProperties.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/properties/JwtProperties.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.dto.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
+
+/**
+ * @param secretKey 토큰을 생성할때 사용되는 키 값
+ * @param accessExpiredMs access 토큰 만료 시간 (ms)
+ */
+@Validated
+@ConfigurationProperties(prefix = "jwt.token")
+public record JwtProperties(@NotBlank String secretKey, @Positive long accessExpiredMs) {}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/LoginRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+public record LoginRequest(@NotBlank @Email String email, @NotBlank String password) {
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/LoginResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/LoginResponse.java
@@ -1,0 +1,7 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+public record LoginResponse(String accessToken) {
+    public static LoginResponse of(String accessToken) {
+        return new LoginResponse(accessToken);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
@@ -41,6 +41,20 @@ public record MemberPrincipal(
                 address);
     }
 
+    /**
+     * JWT 토큰 파싱 후 MemberPrincipal 생성 시 사용
+     */
+    public static MemberPrincipal of(
+            Long id,
+            String email,
+            String nickname,
+            UserRole userRole,
+            double rating,
+            String fileName,
+            Address address) {
+        return MemberPrincipal.of(id, email, null, nickname, userRole, rating, fileName, address);
+    }
+
     public static MemberPrincipal fromEntity(Member member) {
         return MemberPrincipal.of(
                 member.getId(),

--- a/src/main/java/freshtrash/freshtrashbackend/exception/AuthException.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/AuthException.java
@@ -1,15 +1,15 @@
 package freshtrash.freshtrashbackend.exception;
 
-import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
 
 @Getter
-public class AuthException extends CustomException {
-    public AuthException(ErrorCode errorCode) {
-        super(errorCode);
+public class AuthException extends AuthenticationException {
+    public AuthException(String msg, Throwable cause) {
+        super(msg, cause);
     }
 
-    public AuthException(ErrorCode errorCode, Exception causeException) {
-        super(errorCode, causeException);
+    public AuthException(String msg) {
+        super(msg);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/exception/AuthException.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/AuthException.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.exception;
+
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends CustomException {
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthException(ErrorCode errorCode, Exception causeException) {
+        super(errorCode, causeException);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -27,7 +27,12 @@ public enum ErrorCode {
     // Member
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "유저 정보가 존재하지 않습니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다.");
+    ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+
+    // Auth
+    FAILED_AUTHENTICATE(HttpStatus.UNAUTHORIZED, "인증 실패"),
+    EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "Token이 만료되었습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -27,12 +27,7 @@ public enum ErrorCode {
     // Member
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "유저 정보가 존재하지 않습니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
-
-    // Auth
-    FAILED_AUTHENTICATE(HttpStatus.UNAUTHORIZED, "인증 실패"),
-    EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "Token이 만료되었습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+    ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/security/Http401UnauthorizedAuthenticationEntryPoint.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/Http401UnauthorizedAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package freshtrash.freshtrashbackend.security;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class Http401UnauthorizedAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException {
+        response.sendError(HttpStatus.UNAUTHORIZED.value(), authException.getMessage());
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/security/JwtTokenFilter.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/JwtTokenFilter.java
@@ -2,7 +2,6 @@ package freshtrash.freshtrashbackend.security;
 
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.exception.AuthException;
-import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +40,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             setAuthentication(request, tokenProvider.parseOrValidateClaims(accessToken), accessToken);
         } catch (Exception e) {
             log.error("Error occurs during authenticate, {}", e.getMessage());
-            throw new AuthException(ErrorCode.FAILED_AUTHENTICATE);
+            throw new AuthException("Failed authenticate");
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/freshtrash/freshtrashbackend/security/JwtTokenFilter.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/JwtTokenFilter.java
@@ -1,0 +1,70 @@
+package freshtrash.freshtrashbackend.security;
+
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.exception.AuthException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    public static final String ACCESS_TOKEN_HEADER = HttpHeaders.AUTHORIZATION;
+    public static final String TOKEN_PREFIX = "Bearer";
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String accessToken = parseBearerToken(request);
+        try {
+            if (!StringUtils.hasText(accessToken)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            setAuthentication(request, tokenProvider.parseOrValidateClaims(accessToken), accessToken);
+        } catch (Exception e) {
+            log.error("Error occurs during authenticate, {}", e.getMessage());
+            throw new AuthException(ErrorCode.FAILED_AUTHENTICATE);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * reqeust header의 토큰 파싱
+     */
+    private String parseBearerToken(HttpServletRequest request) {
+        String token = request.getHeader(ACCESS_TOKEN_HEADER);
+        if (token != null && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length()).trim();
+        }
+        return token;
+    }
+
+    /**
+     * Set Authentication
+     */
+    private void setAuthentication(HttpServletRequest request, Claims claims, String accessToken) {
+        MemberPrincipal memberPrincipal = tokenProvider.getUserDetails(claims);
+        UsernamePasswordAuthenticationToken authenticated = UsernamePasswordAuthenticationToken.authenticated(
+                memberPrincipal, accessToken, memberPrincipal.getAuthorities());
+        authenticated.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticated);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
@@ -10,13 +10,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.session.SessionManagementFilter;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtTokenFilter jwtTokenFilter) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtTokenFilter jwtTokenFilter, Http401UnauthorizedAuthenticationEntryPoint authenticationEntryPoint) throws Exception {
         return http.csrf()
                 .disable()
                 .authorizeHttpRequests(auth -> auth.requestMatchers(
@@ -27,9 +28,11 @@ public class SecurityConfig {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .formLogin(form -> form.usernameParameter("email"))
-                .addFilterAfter(jwtTokenFilter, SessionManagementFilter.class)
-                .build();
+                    .addFilterAfter(jwtTokenFilter, ExceptionTranslationFilter.class)
+                    .exceptionHandling()
+                    .authenticationEntryPoint(authenticationEntryPoint)
+                .and()
+                    .build();
     }
 
     @Bean

--- a/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
@@ -5,17 +5,18 @@ import freshtrash.freshtrashbackend.service.MemberService;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.session.SessionManagementFilter;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtTokenFilter jwtTokenFilter) throws Exception {
         return http.csrf()
                 .disable()
                 .authorizeHttpRequests(auth -> auth.requestMatchers(
@@ -23,7 +24,11 @@ public class SecurityConfig {
                         .permitAll()
                         .anyRequest()
                         .permitAll())
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
                 .formLogin(form -> form.usernameParameter("email"))
+                .addFilterAfter(jwtTokenFilter, SessionManagementFilter.class)
                 .build();
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/security/TokenInfo.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/TokenInfo.java
@@ -1,0 +1,29 @@
+package freshtrash.freshtrashbackend.security;
+
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Address;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
+
+public record TokenInfo(
+        Long id, String email, String nickname, UserRole userRole, double rating, String fileName, Address address) {
+    public static TokenInfo of(
+            String email, String nickname, String spec, double rating, String fileName, Address address) {
+        String[] sepcs = spec.split(":");
+        return new TokenInfo(
+                Long.parseLong(sepcs[0]),
+                email,
+                nickname,
+                UserRole.valueOf(sepcs[1].substring(5)),
+                rating,
+                fileName,
+                address);
+    }
+
+    public static TokenInfo ofAnonymous() {
+        return new TokenInfo(null, "ANONYMOUS", "ANONYMOUS", UserRole.ANONYMOUS, 0, null, null);
+    }
+
+    public MemberPrincipal toMemberPrincipal() {
+        return MemberPrincipal.of(id, email, null, nickname, userRole, rating, fileName, address);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/security/TokenProvider.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/TokenProvider.java
@@ -1,0 +1,98 @@
+package freshtrash.freshtrashbackend.security;
+
+import freshtrash.freshtrashbackend.dto.properties.JwtProperties;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Address;
+import freshtrash.freshtrashbackend.exception.AuthException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+    private static final String KEY_EMAIL = "email";
+    private static final String KEY_NICKNAME = "nickname";
+    private static final String KEY_SPEC = "spec";
+    private static final String KEY_RATING = "rating";
+    private static final String KEY_FILENAME = "fileName";
+    private static final String KEY_ADDRESS = "address";
+    private final JwtProperties jwtProperties;
+
+    /**
+     * 토큰 발급
+     */
+    public String generateAccessToken(
+            String email, String nickname, String spec, double rating, String fileName, Address address) {
+        Map<String, String> claims = new HashMap<>();
+        claims.put(KEY_EMAIL, email);
+        claims.put(KEY_NICKNAME, nickname);
+        claims.put(KEY_SPEC, spec); // "id:role"
+        claims.put(KEY_RATING, String.valueOf(rating));
+        claims.put(KEY_FILENAME, fileName);
+        claims.put(KEY_ADDRESS, address.toString());
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.accessExpiredMs()))
+                .signWith(getKey(jwtProperties.secretKey()))
+                .compact();
+    }
+
+    /**
+     * 토큰 파싱
+     */
+    public Claims parseOrValidateClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(getKey(jwtProperties.secretKey()))
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(ErrorCode.EXPIRED_TOKEN, e);
+        }
+    }
+
+    public TokenInfo parseSpecification(Claims claims) {
+        try {
+            return TokenInfo.of(
+                    claims.get(TokenProvider.KEY_EMAIL, String.class),
+                    claims.get(TokenProvider.KEY_NICKNAME, String.class),
+                    claims.get(TokenProvider.KEY_SPEC, String.class),
+                    claims.get(TokenProvider.KEY_RATING, Double.class),
+                    claims.get(TokenProvider.KEY_FILENAME, String.class),
+                    claims.get(TokenProvider.KEY_ADDRESS, Address.class));
+        } catch (RuntimeException e) {
+            log.error("failed token parsing");
+            return null;
+        }
+    }
+
+    /**
+     * 토큰에 있는 정보로 UserDetails 생성
+     */
+    public MemberPrincipal getUserDetails(Claims claims) {
+        TokenInfo tokenInfo =
+                Optional.ofNullable(claims).map(this::parseSpecification).orElse(TokenInfo.ofAnonymous());
+        return tokenInfo.toMemberPrincipal();
+    }
+
+    private SecretKey getKey(String key) {
+        return Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/SigInService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/SigInService.java
@@ -34,7 +34,7 @@ public class SigInService {
      */
     private void checkPassword(String inputPassword, String existPassword) {
         if (!passwordEncoder.matches(inputPassword, existPassword)) {
-            throw new AuthException(ErrorCode.INVALID_PASSWORD);
+            throw new AuthException("not matched password");
         }
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/service/SigInService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/SigInService.java
@@ -1,0 +1,53 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.dto.response.LoginResponse;
+import freshtrash.freshtrashbackend.entity.Member;
+import freshtrash.freshtrashbackend.exception.AuthException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SigInService {
+    private final TokenProvider tokenProvider;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberService memberService;
+
+    /**
+     * 로그인
+     */
+    public LoginResponse signIn(String email, String password) {
+        Member member = memberService.getMemberEntityByEmail(email);
+        checkPassword(password, member.getPassword());
+        // 토큰 발급
+        String accessToken = generateAccessToken(email, member);
+        return LoginResponse.of(accessToken);
+    }
+
+    /**
+     * 비밀번호 일치 확인
+     * @param inputPassword 입력한 비밀번호
+     * @param existPassword 기존 비밀번호
+     */
+    private void checkPassword(String inputPassword, String existPassword) {
+        if (!passwordEncoder.matches(inputPassword, existPassword)) {
+            throw new AuthException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    /**
+     * AccessToken 발급
+     */
+    private String generateAccessToken(String email, Member member) {
+        return tokenProvider.generateAccessToken(
+                email,
+                member.getNickname(),
+                String.format("%s:%s", member.getId(), member.getUserRole().getName()),
+                member.getRating(),
+                member.getFileName(),
+                member.getAddress());
+    }
+}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,6 @@
+spring:
+  config.activate.on-profile: security
+jwt:
+  token:
+    secret-key: ${TOKEN_SECRET_KEY}
+    access-expired-ms: ${TOKEN_ACCESS_EXPIRED_MS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
       test:
         - file
         - mail
+        - security
 
 ---
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
         - common
         - file
         - mail
+        - security
       test:
         - file
         - mail

--- a/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
+++ b/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
 import freshtrash.freshtrashbackend.entity.constants.LoginType;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.security.SecurityConfig;
+import freshtrash.freshtrashbackend.security.TokenProvider;
 import freshtrash.freshtrashbackend.service.MemberService;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -16,7 +17,11 @@ import static org.mockito.BDDMockito.given;
 
 @Import(SecurityConfig.class)
 public class TestSecurityConfig {
-    @MockBean private MemberService memberService;
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private TokenProvider tokenProvider;
 
     @BeforeTestMethod
     void securitySetUp() {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 유저가 로그인을 하면 jwt 토큰을 발급하여 프론트로 전달하도록 합니다. jwt 토큰에는 "id, role, nickname, rating, profile image filename, address" 정보를 포함하도록 합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- JWT 토큰 인증을 위한 Security 설정
    - session policy를 stateless 로 변경했습니다.
    - 토큰 인증을 수행하는 JwtTokenFilter를 추가했습니다.
- 토큰 발급/파싱을 수행하는 클래스를 정의했습니다.
    - 토큰 발급 메소드
    - 토큰 파싱 (유효성 검사도 같이 수행합니다) 메소드
    - 토큰 파싱 후 MemberPrincipal로 반환 메소드
- MemberPrincipal에 평점, 파일명(프로필 이미지), 주소 정보를 추가했습니다.
- 로그인 API 구현
    - 로그인 성공 후 accessToken을 발급하고 반환합니다.
    - 비밀번호 일치 여부도 확인합니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- Jwt 토큰의 secret key, expired time 값을 application-security.yml에 추가하고 변수로 처리했습니다.
    - 변수 값들은 노션의 env 페이지에 추가했습니다.
- 테스트 Security 설정 수정
    - test profile에 security profile을 추가했습니다
    - TestSecurityConfig에 TokenProvider 의존성을 추가했습니다
- 인증 실패 Exception 처리
    - AuthenticationEntryPoint를 정의하여 인증 실패 시 다음과 같은 형식의 Response가 반환되도록 반영했습니다.
    - JwtTokenFilter 에서 발생하는 예외를 ExceptionTranslationFilter에서 처리할 수 있도록 JwtTokenFilter의 위치를 ExceptionTranslationFilter 이후로 변경했습니다
      ```
       {
          "timestamp": "2024-04-07T06:48:28.161+00:00",  -> 요청 일시
          "status": 401,
          "error": "Unauthorized",
          "message": {exception message},
          "path": {요청 시도한 endpoint}
      }
      ```


### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #25 
