### PR TITLE
OAuth 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.7.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
@@ -78,7 +78,7 @@ public class WasteApi {
             @PathVariable Long wasteId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         checkIfWriterOrAdmin(memberPrincipal, wasteId);
         wasteService.deleteWaste(wasteId, wasteService.findFileNameOfWaste(wasteId));
-        return ResponseEntity.ok(null);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
@@ -8,8 +8,10 @@ import lombok.Builder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 @Builder
@@ -21,8 +23,10 @@ public record MemberPrincipal(
         String nickname,
         double rating,
         String fileName,
-        Address address)
-        implements UserDetails {
+        Address address,
+        Map<String, Object> oAuth2Attributes)
+        implements UserDetails, OAuth2User {
+
     public static class MemberPrincipalBuilder {
         public MemberPrincipalBuilder authorities(UserRole userRole) {
             this.authorities = Set.of(new SimpleGrantedAuthority(userRole.getName()));
@@ -60,6 +64,16 @@ public record MemberPrincipal(
                 .map(r -> UserRole.valueOf(r.getAuthority().substring(5)))
                 .findFirst()
                 .orElse(UserRole.ANONYMOUS);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oAuth2Attributes;
+    }
+
+    @Override
+    public String getName() {
+        return email;
     }
 
     @Override

--- a/src/main/java/freshtrash/freshtrashbackend/dto/security/OAuthAttributes.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/security/OAuthAttributes.java
@@ -1,0 +1,75 @@
+package freshtrash.freshtrashbackend.dto.security;
+
+import freshtrash.freshtrashbackend.exception.AuthException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OAuthAttributes {
+    private static final String NAVER_REGISTRATION_ID = "Naver";
+    private static final String KAKAO_REGISTRATION_ID = "Kakao";
+    private static final String GOOGLE_REGISTRATION_ID = "Google";
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String provider;
+
+    public static OAuthAttributes of(
+            String name, String email, String provider, Map<String, Object> attributes, String nameAttributeKey) {
+        return new OAuthAttributes(attributes, nameAttributeKey, name, email, provider);
+    }
+
+    public static OAuthAttributes of(
+            String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        if (NAVER_REGISTRATION_ID.equalsIgnoreCase(registrationId)) {
+            return ofNaver("id", attributes);
+        } else if (KAKAO_REGISTRATION_ID.equalsIgnoreCase(registrationId)) {
+            return ofKakao("id", attributes);
+        }
+
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.of(
+                (String) attributes.get("name"),
+                (String) attributes.get("email"),
+                GOOGLE_REGISTRATION_ID,
+                attributes,
+                userNameAttributeName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) Optional.of(attributes.get("response"))
+                .orElseThrow(() -> new AuthException("Invalid Naver OAuth Request"));
+
+        return OAuthAttributes.of(
+                (String) response.get("name"),
+                (String) response.get("email"),
+                NAVER_REGISTRATION_ID,
+                response,
+                userNameAttributeName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) Optional.of(attributes.get("kakao_account"))
+                .orElseThrow(() -> new AuthException("Invalid Kakao OAuth Request"));
+        Map<String, Object> account = (Map<String, Object>) Optional.of(response.get("profile"))
+                .orElseThrow(() -> new AuthException("Invalid Kakao OAuth Request"));
+
+        return OAuthAttributes.of(
+                (String) account.get("nickname"),
+                (String) response.get("email"),
+                KAKAO_REGISTRATION_ID,
+                attributes,
+                userNameAttributeName);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/security/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,36 @@
+package freshtrash.freshtrashbackend.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import freshtrash.freshtrashbackend.dto.response.LoginResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final TokenProvider tokenProvider;
+    private final ObjectMapper mapper;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+        MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
+        String accessToken = tokenProvider.generateAccessToken(
+                principal.email(),
+                principal.nickname(),
+                String.format("%s:%s", principal.id(), principal.getUserRole().getName()),
+                principal.rating(),
+                principal.fileName(),
+                principal.address());
+        response.getOutputStream().println(mapper.writeValueAsString(LoginResponse.of(accessToken)));
+        // TODO: 회원가입되지 않은 계정일 경우 처리
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
@@ -1,6 +1,9 @@
 package freshtrash.freshtrashbackend.security;
 
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.dto.security.OAuthAttributes;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
+import freshtrash.freshtrashbackend.exception.MemberException;
 import freshtrash.freshtrashbackend.service.MemberService;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -9,15 +12,27 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
-import org.springframework.security.web.session.SessionManagementFilter;
+
+import java.util.UUID;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtTokenFilter jwtTokenFilter, Http401UnauthorizedAuthenticationEntryPoint authenticationEntryPoint) throws Exception {
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService,
+            JwtTokenFilter jwtTokenFilter,
+            Http401UnauthorizedAuthenticationEntryPoint authenticationEntryPoint,
+            CustomOAuth2SuccessHandler customOAuth2SuccessHandler)
+            throws Exception {
         return http.csrf()
                 .disable()
                 .authorizeHttpRequests(auth -> auth.requestMatchers(
@@ -28,11 +43,45 @@ public class SecurityConfig {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                    .addFilterAfter(jwtTokenFilter, ExceptionTranslationFilter.class)
-                    .exceptionHandling()
-                    .authenticationEntryPoint(authenticationEntryPoint)
+                .oauth2Login(oAuth -> oAuth.userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
+                        .successHandler(customOAuth2SuccessHandler))
+                .addFilterAfter(jwtTokenFilter, ExceptionTranslationFilter.class)
+                .exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPoint)
                 .and()
-                    .build();
+                .build();
+    }
+
+    @Bean
+    public OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService(
+            MemberService memberService, PasswordEncoder passwordEncoder) {
+        final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+
+        return userRequest -> {
+            OAuth2User oAuth2User = delegate.loadUser(userRequest);
+            String registrationId = userRequest.getClientRegistration().getRegistrationId();
+            String userNameAttributeName = userRequest
+                    .getClientRegistration()
+                    .getProviderDetails()
+                    .getUserInfoEndpoint()
+                    .getUserNameAttributeName();
+            OAuthAttributes attributes =
+                    OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+            String email = attributes.getEmail();
+            String dummyPassword = passwordEncoder.encode("{bcrypt}" + UUID.randomUUID());
+
+            // 회원이 존재하지 않는다면 저장하지 않고 회원가입이 안된 상태로 반환
+            try {
+                return MemberPrincipal.fromEntity(memberService.getMemberEntityByEmail(email));
+            } catch (MemberException e) {
+                return MemberPrincipal.builder()
+                        .email(email)
+                        .password(dummyPassword)
+                        .nickname(attributes.getName())
+                        .authorities(UserRole.ANONYMOUS)
+                        .build();
+            }
+        };
     }
 
     @Bean

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,5 +1,51 @@
 spring:
   config.activate.on-profile: security
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_OAUTH_CLIENT_ID}
+            client-secret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+            scope:
+              - profile
+              - email
+          naver:
+            client-id: ${NAVER_OAUTH_CLIENT_ID}
+            client-secret: ${NAVER_OAUTH_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - name
+              - email
+          kakao:
+            # REST API 키
+            client-id: ${KAKAO_OAUTH_CLIENT_ID}
+            # 보안 > Client Secret 코드
+            client-secret: ${KAKAO_OAUTH_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-authentication-method: POST
+            scope:
+              - account_email
+              - profile_nickname
+        provider:
+          naver:
+            # https://developers.naver.com/docs/login/devguide/devguide.md#3-4-2-%EB%84%A4%EC%9D%B4%EB%B2%84-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%97%B0%EB%8F%99-url-%EC%83%9D%EC%84%B1%ED%95%98%EA%B8%B0
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            # https://developers.naver.com/docs/login/devguide/devguide.md#3-4-4-%EC%A0%91%EA%B7%BC-%ED%86%A0%ED%81%B0-%EB%B0%9C%EA%B8%89-%EC%9A%94%EC%B2%AD
+            token-uri: https://nid.naver.com/oauth2.0/token
+            # https://developers.naver.com/docs/login/devguide/devguide.md#3-4-5-%EC%A0%91%EA%B7%BC-%ED%86%A0%ED%81%B0%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%98%EC%97%AC-%ED%94%84%EB%A1%9C%ED%95%84-api-%ED%98%B8%EC%B6%9C%ED%95%98%EA%B8%B0
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-code
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
+            token-uri: https://kauth.kakao.com/oauth/token
+            # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 jwt:
   token:
     secret-key: ${TOKEN_SECRET_KEY}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- Email/Password 입력으로 로그인할 수 있을 뿐만 아니라 네이버, 구글, 카카오 계정으로 로그인할 수 있도록 OAuth 기능을 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- `spring-boot-starter-oauth2-client` dependency 추가
- `application-security.yml`에 구글, 네이버, 카카오의 client-id, client-secret 등 OAuth 로그인 기능을 구현하는데 필요한 속성 값들을 추가했습니다.
    - 값은 노션의 env 페이지에 추가했습니다.
- `MemberPrincipal`를 OAuth2User도 implements하여 OAuth2 로그인 후 반환되고 SecurityContextHolder에 저장될 객체로 사용합니다.
- SecurityConfig 수정
    - OAuth2UserService 구현 및 빈 등록
        - resource server로 부터 받은 userinfo를 통해 MemberPrincipal(OAuth2User)을 생성하여 반환합니다.
        - 회원가입되지 않은 계정이라면 "ANONYMOUS" 권한으로 생성하여 서비스를 이용할 수 없도록 합니다. 이후 프론트와 협의하여 회원가입 페이지로 redirect 하는 등 추가 작업을 할 예정입니다.
    - successHandler를 추가 정의하여 OAuth2 로그인 성공 후 AccessToken을 발급하여 Response합니다.
- 로그인 요청 URL 정리 -> 노션의 API 명세서에도 추가했습니다
    - Google: `/oauth2/authorization/google`
    - Kakao: `/oauth2/authorization/kakao`
    - Naver:  `/oauth2/authorization/naver`
- 테스트는 직접 브라우저에 URL을 입력하여 수행했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #39 
