### PR TITLE
알람 SSE 연결 요청 API 구현

### DIFF
--- a/database/initdb.d/create_table.sql
+++ b/database/initdb.d/create_table.sql
@@ -40,3 +40,15 @@ CREATE TABLE `wastes`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='폐기물';
 
+CREATE TABLE `alarms`
+(
+    `id`         bigint AUTO_INCREMENT NOT NULL,
+    `member_id`  bigint                NOT NULL,
+    `alarm_type` varchar(255)          NOT NULL,
+    `alarm_args` json                  NOT NULL,
+    `created_at` datetime              NOT NULL,
+    `read_at`    datetime,
+    PRIMARY KEY (`id`),
+    foreign key (`member_id`) references members (id) on delete cascade
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='알람';

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -2,7 +2,9 @@ insert into members(email, password, rating, nickname, address, file_name, login
                     created_at, modified_at)
 values ('abc@never.com', '$2a$10$4mbVj4n1KeBmNsQCeXZpZujVo.cmXMdPIoDUQ1c1jkR87LdBA4gJW', 10, 'abc',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
-        'test.png', 'GOOGLE', 'USER', 'ACTIVE', now(), null);
+        'test.png', 'GOOGLE', 'USER', 'ACTIVE', now(), null),
+       ('def@never.com', '$2a$10$GdkQ8WABeKqQOXkMaildcePPAINn3IBs2V/As1c/S8Q9W1K7SfWsG', 0, 'def',
+        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null);
 
 
 insert into wastes(member_id, title, content, waste_price, like_count, view_count, file_name, waste_category, waste_status,
@@ -10,3 +12,6 @@ insert into wastes(member_id, title, content, waste_price, like_count, view_coun
 values (1, 'title', 'content', 0, 0, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
         now(), null, null);
+
+insert into alarms(member_id, alarm_type, alarm_args, created_at, read_at) values
+(1, 'CHAT', json_object('fromMemberId', '2', 'targetId', '1'), now(), null);

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
@@ -1,0 +1,26 @@
+package freshtrash.freshtrashbackend.controller;
+
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.service.AlarmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/v1/notis")
+@RequiredArgsConstructor
+public class AlarmApi {
+    private final AlarmService alarmService;
+
+    /**
+     * SSE 연결 요청
+     */
+    @GetMapping("/subscribe")
+    public ResponseEntity<SseEmitter> subscribe(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        return ResponseEntity.ok(alarmService.connectAlarm(memberPrincipal.id()));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
@@ -1,0 +1,68 @@
+package freshtrash.freshtrashbackend.entity;
+
+import freshtrash.freshtrashbackend.entity.constants.AlarmType;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import lombok.*;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Getter
+@ToString
+@Table(name = "alarms")
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@TypeDef(name = "json", typeClass = JsonType.class)
+public class Alarm implements Persistable<Long> {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private AlarmType alarmType;
+
+    @Column(nullable = false, columnDefinition = "longtext")
+    @Type(type = "json")
+    private AlarmArgs alarmArgs;
+
+    @Setter
+    private LocalDateTime readAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @ToString.Exclude
+    @ManyToOne(optional = false, fetch = LAZY)
+    @JoinColumn(name = "memberId", insertable = false, updatable = false)
+    private Member member; // 알람을 받는 유저
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Builder
+    public Alarm(AlarmType alarmType, AlarmArgs alarmArgs, Long memberId) {
+        this.alarmType = alarmType;
+        this.alarmArgs = alarmArgs;
+        this.memberId = memberId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return Objects.isNull(this.id);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/AlarmArgs.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/AlarmArgs.java
@@ -1,0 +1,13 @@
+package freshtrash.freshtrashbackend.entity;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@Builder
+@EqualsAndHashCode
+public class AlarmArgs {
+    private Long fromMemberId; // 알람을 발생시킨 유저
+    private Long targetId; // 알람 대상 (waste, chat, ...)
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -66,6 +66,10 @@ public class Member extends AuditingAt implements Persistable<Long> {
     @OneToMany(mappedBy = "member", cascade = ALL, fetch = LAZY)
     private Set<Waste> wastes = new LinkedHashSet<>();
 
+    @ToString.Exclude
+    @OneToMany(mappedBy = "member", cascade = ALL, fetch = LAZY)
+    private Set<Alarm> alarms = new LinkedHashSet<>();
+
     @PrePersist
     private void prePersist() {
         this.rating = 0;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
@@ -1,0 +1,10 @@
+package freshtrash.freshtrashbackend.entity.constants;
+
+public enum AlarmType {
+    CHAT,
+    TRANSACTION,
+    BIDDING,
+    PAY,
+    RECEIVE,
+    NOT_PAY
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/AlarmException.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/AlarmException.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.exception;
+
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AlarmException extends CustomException {
+    public AlarmException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AlarmException(ErrorCode errorCode, Exception causeException) {
+        super(errorCode, causeException);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -27,7 +27,10 @@ public enum ErrorCode {
     // Member
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "유저 정보가 존재하지 않습니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다.");
+    ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+
+    // Alarm
+    ALARM_CONNECT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알람을 위한 연결 시도 실패");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
@@ -1,0 +1,6 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.entity.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/EmitterRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/EmitterRepository.java
@@ -1,0 +1,34 @@
+package freshtrash.freshtrashbackend.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Repository
+public class EmitterRepository {
+    private final Map<String, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+
+    public SseEmitter save(Long memberId, SseEmitter sseEmitter) {
+        String key = getKey(memberId);
+        emitterMap.put(key, sseEmitter);
+        return sseEmitter;
+    }
+
+    public Optional<SseEmitter> get(Long memberId) {
+        String key = getKey(memberId);
+        return Optional.ofNullable(emitterMap.get(key));
+    }
+
+    public void delete(Long memberId) {
+        emitterMap.remove(getKey(memberId));
+    }
+
+    private String getKey(Long memberId) {
+        return "Emitter:Id:" + memberId;
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -5,12 +5,14 @@ import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.AlarmRepository;
 import freshtrash.freshtrashbackend.repository.EmitterRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AlarmService {
@@ -23,6 +25,10 @@ public class AlarmService {
         emitterRepository.save(memberId, sseEmitter);
         sseEmitter.onCompletion(() -> emitterRepository.delete(memberId));
         sseEmitter.onTimeout(() -> emitterRepository.delete(memberId));
+        sseEmitter.onError((e) -> {
+            emitterRepository.delete(memberId);
+            log.error("SseEmitter Error: ", e);
+        });
 
         try {
             // 처음 SSE 연결 후 아무런 이벤트도 보내지 않으면 재연결 요청을 보낼때나 연결 요청 자체에서 에러가 발생합니다. 따라서 임의로 데이터를 전송합니다.

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -1,0 +1,36 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.exception.AlarmException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.repository.AlarmRepository;
+import freshtrash.freshtrashbackend.repository.EmitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+    private static final Long SSE_TIMEOUT = TimeUnit.MINUTES.toMillis(30);
+    private final EmitterRepository emitterRepository;
+    private final AlarmRepository alarmRepository;
+
+    public SseEmitter connectAlarm(Long memberId) {
+        SseEmitter sseEmitter = new SseEmitter(SSE_TIMEOUT);
+        emitterRepository.save(memberId, sseEmitter);
+        sseEmitter.onCompletion(() -> emitterRepository.delete(memberId));
+        sseEmitter.onTimeout(() -> emitterRepository.delete(memberId));
+
+        try {
+            // 처음 SSE 연결 후 아무런 이벤트도 보내지 않으면 재연결 요청을 보낼때나 연결 요청 자체에서 에러가 발생합니다. 따라서 임의로 데이터를 전송합니다.
+            sseEmitter.send(SseEmitter.event().id("").name("connect").data("connect completed"));
+        } catch (IOException e) {
+            throw new AlarmException(ErrorCode.ALARM_CONNECT_ERROR, e);
+        }
+
+        return sseEmitter;
+    }
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 알람을 전송하기 전 SSE 연결을 요청하기 위한 API을 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- SSE 연결 요청 API 추가 구현했습니다
- SseEmitter를 저장/관리하기위한 EmitterRepository를 추가했습니다
    - Thread-safe한 ConcurrentHashMap 자료구조를 사용했습니다
    - key에는 임의로 "Emitter:Id:" + memberId로 지정합니다.
- SSE 연결을 위한 로직을 구현했습니다
    - 임의로 timeout은 30분으로 지정하고 completion, timeout event 발생시 emitter를 삭제하도록 했습니다
    - 첫 SSE 연결 후 임의로 데이터를 전송하여 `503` 에러를 예방합니다
- API 테스트는 Postman에서 수행했습니다. (Insomnia에서는 안되네요;;)
    <img width="1154" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/2aa78c06-ee7a-4bf9-8067-711b7609744c">

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #46
