### PR TITLE
알람 전체 조회 API 구현

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
@@ -1,8 +1,12 @@
 package freshtrash.freshtrashbackend.controller;
 
+import freshtrash.freshtrashbackend.dto.AlarmDto;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.service.AlarmService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +19,16 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class AlarmApi {
     private final AlarmService alarmService;
+
+    /**
+     * 현재 로그인한 사용자에게 온 알람 조회
+     */
+    // TODO: 이후 프론트와 협의를 통해 페이징 처리가 아닌 리스트로 반환되도록 수정될 수 있습니다
+    @GetMapping
+    public ResponseEntity<Page<AlarmDto>> getAlarms(
+            @PageableDefault Pageable pageable, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        return ResponseEntity.ok(alarmService.getAlarms(memberPrincipal.id(), pageable));
+    }
 
     /**
      * SSE 연결 요청

--- a/src/main/java/freshtrash/freshtrashbackend/dto/AlarmDto.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/AlarmDto.java
@@ -1,0 +1,11 @@
+package freshtrash.freshtrashbackend.dto;
+
+import freshtrash.freshtrashbackend.entity.Alarm;
+import freshtrash.freshtrashbackend.entity.AlarmArgs;
+import freshtrash.freshtrashbackend.entity.constants.AlarmType;
+
+public record AlarmDto(Long id, AlarmType alarmType, AlarmArgs alarmArgs) {
+    public static AlarmDto fromEntity(Alarm alarm) {
+        return new AlarmDto(alarm.getId(), alarm.getAlarmType(), alarm.getAlarmArgs());
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/AlarmArgs.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/AlarmArgs.java
@@ -1,12 +1,13 @@
 package freshtrash.freshtrashbackend.entity;
 
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AlarmArgs {
     private Long fromMemberId; // 알람을 발생시킨 유저
     private Long targetId; // 알람 대상 (waste, chat, ...)

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
@@ -1,6 +1,10 @@
 package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.Alarm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlarmRepository extends JpaRepository<Alarm, Long> {}
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+    Page<Alarm> findAllByMember_IdAndReadAtIsNull(Long memberId, Pageable pageable);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -1,11 +1,14 @@
 package freshtrash.freshtrashbackend.service;
 
+import freshtrash.freshtrashbackend.dto.AlarmDto;
 import freshtrash.freshtrashbackend.exception.AlarmException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.AlarmRepository;
 import freshtrash.freshtrashbackend.repository.EmitterRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -20,6 +23,17 @@ public class AlarmService {
     private final EmitterRepository emitterRepository;
     private final AlarmRepository alarmRepository;
 
+    /**
+     * 전체 알람 조회
+     * - 읽지 않은 알람(readAt == null)만 조회
+     */
+    public Page<AlarmDto> getAlarms(Long memberId, Pageable pageable) {
+        return alarmRepository.findAllByMember_IdAndReadAtIsNull(memberId, pageable).map(AlarmDto::fromEntity);
+    }
+
+    /**
+     * SSE 연결 요청
+     */
     public SseEmitter connectAlarm(Long memberId) {
         SseEmitter sseEmitter = new SseEmitter(SSE_TIMEOUT);
         emitterRepository.save(memberId, sseEmitter);


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 읽지 않은 모든 알람을 현재 로그인한 유저가 볼 수 있도록 전체 조회하는 API를 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 알람 전체 조회 API 구현
  - 임의로 페이징 처리를 적용했으며 이후 프론트와 협의를 통해 리스트로 변경될 수 있습니다.
- 알람 조회 쿼리 메소드 추가
  - 현재 로그인한 유저의 ID와 읽지 않은 알람(readAt=null)만 조회합니다.
- AlarmArgs 수정
    - `the given string value ... cannot be transformed to json object` 예외가 발생하여 `@NoArgsConstructor`를 적용하여 해결했습니다.
- API 테스트
    ![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/63e3af73-ffdd-403d-9db2-f59197e036b0)


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #47 
