### PR TITLE
관심폐기물 추가 또는 삭제 

### DIFF
--- a/database/initdb.d/create_table.sql
+++ b/database/initdb.d/create_table.sql
@@ -40,6 +40,7 @@ CREATE TABLE `wastes`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='폐기물';
 
+
 CREATE TABLE `waste_reviews`
 (
     `id`         bigint AUTO_INCREMENT NOT NULL,
@@ -52,3 +53,17 @@ CREATE TABLE `waste_reviews`
     foreign key (`waste_id`) references wastes (id) on delete cascade
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='폐기물 리뷰';
+
+CREATE TABLE `waste_likes`
+(
+    `id`         bigint AUTO_INCREMENT NOT NULL,
+    `member_id`  bigint                NOT NULL,
+    `waste_id`   bigint                NOT NULL,
+    `created_at` datetime              NOT NULL,
+    PRIMARY KEY (`id`),
+    foreign key (`member_id`) references members (id) on delete cascade,
+    foreign key (`waste_id`) references wastes (id) on delete cascade
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='관심 폐기물';
+
+CREATE UNIQUE INDEX member_id_and_waste_id ON waste_likes (member_id, waste_id);

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -2,11 +2,19 @@ insert into members(email, password, rating, nickname, address, file_name, login
                     created_at, modified_at)
 values ('abc@never.com', '$2a$10$4mbVj4n1KeBmNsQCeXZpZujVo.cmXMdPIoDUQ1c1jkR87LdBA4gJW', 10, 'abc',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
-        'test.png', 'GOOGLE', 'USER', 'ACTIVE', now(), null);
+        'test.png', 'GOOGLE', 'USER', 'ACTIVE', now(), null),
+       ('def@never.com', '$2a$10$GdkQ8WABeKqQOXkMaildcePPAINn3IBs2V/As1c/S8Q9W1K7SfWsG', 0, 'def',
+        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null);
 
 
-insert into wastes(member_id, title, content, waste_price, like_count, view_count, file_name, waste_category, waste_status,
+
+insert into wastes(member_id, title, content, waste_price, like_count, view_count, file_name, waste_category,
+                   waste_status,
                    sell_status, address, created_at, modified_at, transaction_at)
 values (1, 'title', 'content', 0, 0, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
         now(), null, null);
+
+
+insert into waste_likes(member_id, waste_id, created_at)
+values (2, 1, now());

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -11,8 +11,11 @@ values ('abc@never.com', '$2a$10$4mbVj4n1KeBmNsQCeXZpZujVo.cmXMdPIoDUQ1c1jkR87Ld
 insert into wastes(member_id, title, content, waste_price, like_count, view_count, file_name, waste_category,
                    waste_status,
                    sell_status, address, created_at, modified_at, transaction_at)
-values (1, 'title', 'content', 0, 0, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING',
+values (1, 'title', 'content', 0, 1, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
+        now(), null, null),
+       (2, '보물단지1', '폐기물 설명 내용', 0, 0, 0, '보물단지이미지.png', 'HEALTH', 'GOOD', 'ONGOING',
+        json_object('zipcode', '16255', 'state', '경기도', 'city', '수원시', 'district', '팔달구', 'detail', '창룡대로'),
         now(), null, null);
 
 

--- a/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
@@ -6,7 +6,7 @@ import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
 import freshtrash.freshtrashbackend.dto.response.ApiResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
-import freshtrash.freshtrashbackend.entity.constants.LikeStatus;
+import freshtrash.freshtrashbackend.dto.constants.LikeStatus;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.exception.WasteException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;

--- a/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
@@ -122,6 +122,7 @@ public class WasteApi {
         checkIfNotWriter(memberPrincipal, wasteId);
 
         // TODO likeCount가 변경된 관심수를 반환하도록 변경 예정
+
         // 관심 추가 또는 삭제
         int likeCount = wasteService.addOrDeleteWasteLike(likeStatus, memberPrincipal.id(), wasteId);
 

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/LikeStatus.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/LikeStatus.java
@@ -1,0 +1,6 @@
+package freshtrash.freshtrashbackend.dto.constants;
+
+public enum LikeStatus {
+    LIKE,
+    UNLIKE
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/WasteLike.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/WasteLike.java
@@ -12,7 +12,9 @@ import java.util.Objects;
 
 @Getter
 @ToString
-@Table(name = "waste_likes")
+@Table(
+        name = "waste_likes",
+        indexes = @Index(name = "member_id_and_waste_id", columnList = "memberId, wasteId", unique = true))
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/WasteLike.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/WasteLike.java
@@ -1,0 +1,57 @@
+package freshtrash.freshtrashbackend.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.Persistable;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@ToString
+@Table(name = "waste_likes")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WasteLike implements Persistable<Long> {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId", insertable = false, updatable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wasteId", insertable = false, updatable = false)
+    private Waste waste;
+
+    @Column(nullable = false)
+    private Long wasteId;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private WasteLike(Long memberId, Long wasteId) {
+        this.memberId = memberId;
+        this.wasteId = wasteId;
+    }
+
+    public static WasteLike of(Long memberId, Long wasteId) {
+        return new WasteLike(memberId, wasteId);
+    }
+
+    @Override
+    public boolean isNew() {
+        return Objects.isNull(this.id);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/WasteLike.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/WasteLike.java
@@ -3,6 +3,7 @@ package freshtrash.freshtrashbackend.entity;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
@@ -14,6 +15,7 @@ import java.util.Objects;
 @Table(name = "waste_likes")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class WasteLike implements Persistable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/LikeStatus.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/LikeStatus.java
@@ -1,6 +1,0 @@
-package freshtrash.freshtrashbackend.entity.constants;
-
-public enum LikeStatus {
-    LIKE,
-    UNLIKE
-}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/LikeStatus.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/LikeStatus.java
@@ -1,0 +1,6 @@
+package freshtrash.freshtrashbackend.entity.constants;
+
+public enum LikeStatus {
+    LIKE,
+    UNLIKE
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
     EMPTY_ADDRESS(HttpStatus.BAD_REQUEST, "주소가 입력되지 않았습니다."),
     NOT_FOUND_WASTE(HttpStatus.NOT_FOUND, "폐기물 정보가 존재하지 않습니다."),
     FORBIDDEN_WASTE(HttpStatus.FORBIDDEN, "폐기물에 대한 권한이 없습니다."),
+    OWNER_WASTE_CANT_LIKE(HttpStatus.BAD_REQUEST, "본인 폐기물에는 관심표시할 수 없습니다."),
+    UN_MATCHED_LIKE_STATUS(HttpStatus.BAD_REQUEST, "폐기물 관심 상태가 잘못되었습니다."),
 
     // Review
     ALREADY_EXISTS_REVIEW(HttpStatus.BAD_REQUEST, "이미 리뷰가 등록되었습니다."),

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteLikeRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteLikeRepository.java
@@ -1,0 +1,6 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.entity.WasteLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WasteLikeRepository extends JpaRepository<WasteLike, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteLikeRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteLikeRepository.java
@@ -3,4 +3,8 @@ package freshtrash.freshtrashbackend.repository;
 import freshtrash.freshtrashbackend.entity.WasteLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WasteLikeRepository extends JpaRepository<WasteLike, Long> {}
+public interface WasteLikeRepository extends JpaRepository<WasteLike, Long> {
+    boolean existsByMemberIdAndWasteId(Long memberId, Long wasteId);
+
+    void deleteByMemberIdAndWasteId(Long memberId, Long wasteId);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
@@ -5,12 +5,15 @@ import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface WasteRepository extends JpaRepository<Waste, Long> {
+
     @EntityGraph(attributePaths = "member")
     Optional<Waste> findById(Long wasteId);
 
@@ -20,4 +23,8 @@ public interface WasteRepository extends JpaRepository<Waste, Long> {
     Optional<FileNameSummary> findFileNameById(Long wasteId);
 
     boolean existsByIdAndMember_Id(Long wasteId, Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Waste w set w.likeCount = w.likeCount + :updateCount where w.id = :wasteId")
+    int updateLikeCount(@Param("wasteId") Long wasteId, @Param("updateCount") int updateCount);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
@@ -1,11 +1,11 @@
 package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.Waste;
+
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -25,6 +25,6 @@ public interface WasteRepository extends JpaRepository<Waste, Long> {
     boolean existsByIdAndMember_Id(Long wasteId, Long memberId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("update Waste w set w.likeCount = w.likeCount + :updateCount where w.id = :wasteId")
-    int updateLikeCount(@Param("wasteId") Long wasteId, @Param("updateCount") int updateCount);
+    @Query("update Waste w set w.likeCount = w.likeCount + ?2 where w.id = ?1")
+    int updateLikeCount(Long wasteId, int updateCount);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -8,7 +8,7 @@ import freshtrash.freshtrashbackend.entity.Waste;
 import freshtrash.freshtrashbackend.entity.WasteReview;
 import freshtrash.freshtrashbackend.exception.ReviewException;
 import freshtrash.freshtrashbackend.entity.WasteLike;
-import freshtrash.freshtrashbackend.entity.constants.LikeStatus;
+import freshtrash.freshtrashbackend.dto.constants.LikeStatus;
 import freshtrash.freshtrashbackend.exception.WasteException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.WasteLikeRepository;

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -5,13 +5,10 @@ import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Waste;
-<<<<<<< HEAD
 import freshtrash.freshtrashbackend.entity.WasteReview;
 import freshtrash.freshtrashbackend.exception.ReviewException;
-=======
 import freshtrash.freshtrashbackend.entity.WasteLike;
 import freshtrash.freshtrashbackend.entity.constants.LikeStatus;
->>>>>>> 7d8bedc (feat: #30-관심폐기물 추가 또는 삭제 구현)
 import freshtrash.freshtrashbackend.exception.WasteException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.WasteLikeRepository;

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -119,11 +119,11 @@ public class WasteService {
         isPossibleLikeUpdate(likeStatus, memberId, wasteId);
 
         if (likeStatus == LikeStatus.LIKE) {
-            wasteLikeRepository.deleteByMemberIdAndWasteId(memberId, wasteId);
-            updateCount = -1;
-        } else if (likeStatus == LikeStatus.UNLIKE) {
             wasteLikeRepository.save(WasteLike.of(memberId, wasteId));
             updateCount = 1;
+        } else if (likeStatus == LikeStatus.UNLIKE) {
+            wasteLikeRepository.deleteByMemberIdAndWasteId(memberId, wasteId);
+            updateCount = -1;
         }
 
         // update likeCount

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -135,6 +135,7 @@ public class WasteService {
      */
     public void isPossibleLikeUpdate(LikeStatus likeStatus, Long memberId, Long wasteId) {
         boolean existsLike = wasteLikeRepository.existsByMemberIdAndWasteId(memberId, wasteId);
+
         if ((likeStatus == LikeStatus.LIKE && existsLike) || (likeStatus == LikeStatus.UNLIKE && !existsLike)) {
             throw new WasteException(ErrorCode.UN_MATCHED_LIKE_STATUS);
         }

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -112,6 +112,7 @@ public class WasteService {
     /**
      * 관심폐기물 표시 또는 제거
      */
+    @Transactional
     public int addOrDeleteWasteLike(LikeStatus likeStatus, Long memberId, Long wasteId) {
         int updateCount = 0;
 


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
폐기물 관심 추가 또는 삭제 하는 기능입니다.
- #30 
- #31 
- 두가지 PR리뷰받아 #24로 merge되었고, #24를 develop으로 merge하는 PR입니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
  - WasteLike entity 에서 Member, Waste테이블과 연관관계 설정
  - WasteLikeRepository 생성
  - create_table.sql 에 waste_likes 테이블 create문 추가 
  - insert_data.sql 에 waste_likes insert문 추가, waste_likes에서 본인작성폐기물에 관심표시 안되므로 member insert문 추가 작성
  - 관심 추가 또는 삭제 기능 구현(wasteService) : LikeStatue = LIKE 일때 wasteLikes에 관심추가된 데이터가 없으면 관심 추가 후 해당폐기물의 likecount 1개 증가, LikeStatue = UNLIKE 일때 wasteLikes에 관심추가된 데이터가 있으면 관심 삭제 후 해당 폐기물의 likecount 1개 감소 
- 이미 #30 #31 로 PR받은 사항이라 develop으로 충돌 안나도록 적용 하였습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음 

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed :#24
