### PR TITLE
Member 엔티티에 빌더 패턴 적용 및 관련 DTO, 테스트 코드 수정

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/SignUpRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/SignUpRequest.java
@@ -10,6 +10,13 @@ import javax.validation.constraints.NotBlank;
 
 public record SignUpRequest(@NotBlank String nickname, @NotBlank @Email String email, @NotBlank String password) {
     public Member toEntity() {
-        return Member.of(email, password, nickname, LoginType.EMAIL, UserRole.USER, AccountStatus.ACTIVE);
+        return Member.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .loginType(LoginType.EMAIL)
+                .userRole(UserRole.USER)
+                .accountStatus(AccountStatus.ACTIVE)
+                .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -14,6 +14,9 @@ import javax.persistence.*;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static javax.persistence.CascadeType.ALL;
+import static javax.persistence.FetchType.LAZY;
+
 @Entity
 @Table(name = "members")
 @Getter
@@ -60,14 +63,14 @@ public class Member extends AuditingAt implements Persistable<Long> {
     private AccountStatus accountStatus;
 
     @ToString.Exclude
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "member", cascade = ALL, fetch = LAZY)
     private Set<Waste> wastes = new LinkedHashSet<>();
 
     @PrePersist
     private void prePersist() {
         this.rating = 0;
     }
-    
+
     @Builder // 빌더 패턴 적용
     public Member(String email, String password, String nickname, Address address, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus) {
         this.email = email;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -14,14 +14,11 @@ import javax.persistence.*;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static javax.persistence.CascadeType.ALL;
-import static javax.persistence.FetchType.LAZY;
-
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members")
 @Getter
 @ToString(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @TypeDef(name = "json", typeClass = JsonType.class)
 public class Member extends AuditingAt implements Persistable<Long> {
@@ -63,37 +60,20 @@ public class Member extends AuditingAt implements Persistable<Long> {
     private AccountStatus accountStatus;
 
     @ToString.Exclude
-    @OneToMany(mappedBy = "member", cascade = ALL, fetch = LAZY)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<Waste> wastes = new LinkedHashSet<>();
 
-    @PrePersist
-    private void prePersist() {
-        this.rating = 0;
-    }
-
-    private Member(
-            String email,
-            String password,
-            String nickname,
-            LoginType loginType,
-            UserRole userRole,
-            AccountStatus accountStatus) {
+    @Builder // 빌더 패턴 적용
+    public Member(String email, String password, String nickname, Address address, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+        this.address = address;
+        this.fileName = fileName;
         this.loginType = loginType;
         this.userRole = userRole;
         this.accountStatus = accountStatus;
-    }
-
-    public static Member of(
-            String email,
-            String password,
-            String nickname,
-            LoginType loginType,
-            UserRole userRole,
-            AccountStatus accountStatus) {
-        return new Member(email, password, nickname, loginType, userRole, accountStatus);
+        this.rating = 0;
     }
 
     @Override

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -66,11 +66,6 @@ public class Member extends AuditingAt implements Persistable<Long> {
     @OneToMany(mappedBy = "member", cascade = ALL, fetch = LAZY)
     private Set<Waste> wastes = new LinkedHashSet<>();
 
-    @PrePersist
-    private void prePersist() {
-        this.rating = 0;
-    }
-
     @Builder // 빌더 패턴 적용
     public Member(String email, String password, String nickname, Address address, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus) {
         this.email = email;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -63,6 +63,11 @@ public class Member extends AuditingAt implements Persistable<Long> {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<Waste> wastes = new LinkedHashSet<>();
 
+    @PrePersist
+    private void prePersist() {
+        this.rating = 0;
+    }
+    
     @Builder // 빌더 패턴 적용
     public Member(String email, String password, String nickname, Address address, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus) {
         this.email = email;
@@ -73,7 +78,6 @@ public class Member extends AuditingAt implements Persistable<Long> {
         this.loginType = loginType;
         this.userRole = userRole;
         this.accountStatus = accountStatus;
-        this.rating = 0;
     }
 
     @Override

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -46,10 +46,19 @@ public class Fixture {
             LoginType loginType,
             UserRole userRole,
             AccountStatus accountStatus) {
-        Member member = Member.of(email, password, nickname, loginType, userRole, accountStatus);
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .loginType(loginType)
+                .userRole(userRole)
+                .accountStatus(accountStatus)
+                .build();
+
         ReflectionTestUtils.setField(member, "id", 1L);
         ReflectionTestUtils.setField(member, "fileName", "test.png");
         ReflectionTestUtils.setField(member, "address", Fixture.createAddress());
+
         return member;
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
`Member` 엔티티에 빌더 패턴을 적용하고, 이에 따라 `SignUpRequest` DTO의 `toEntity` 메소드와 관련 테스트 코드를 수정합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
- `Member` 엔티티에 빌더 패턴 적용.
- `SignUpRequest` DTO의 `toEntity` 메소드에서 `Member` 엔티티 생성 시 빌더 패턴 사용으로 변경.
- `Member` 엔티티의 생성 과정을 테스트하는 코드를 빌더 패턴 사용으로 갱신.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
없음

## Issue Tags
- Closed: #44 
