### PR TITLE
폐기물 제목, 주소(읍면동) 검색 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,maven,intellij+all,macos,windows
 .env
 **/imgs/
+
+### Querydsl
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.1.4'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'freshtrash'
@@ -48,8 +55,41 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
+
+    //queryDSL
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = 'src/main/generated'
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+// java source set 에 querydsl Qclass 위치 추가
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(querydslDir)
+}
+
+jar {
+    enabled = false
 }

--- a/src/main/java/freshtrash/freshtrashbackend/config/JSONMetadataBuilderContributor.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/JSONMetadataBuilderContributor.java
@@ -1,0 +1,17 @@
+package freshtrash.freshtrashbackend.config;
+
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.spi.MetadataBuilderContributor;
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+public class JSONMetadataBuilderContributor implements MetadataBuilderContributor {
+
+    @Override
+    public void contribute(MetadataBuilder metadataBuilder) {
+        metadataBuilder.applySqlFunction(
+                "JSON_CONTAINS", new StandardSQLFunction("JSON_CONTAINS", StandardBasicTypes.BOOLEAN));
+        metadataBuilder.applySqlFunction(
+                "JSON_QUOTE", new StandardSQLFunction("JSON_QUOTE", StandardBasicTypes.STRING));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/config/JpaConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/JpaConfig.java
@@ -1,8 +1,17 @@
 package freshtrash.freshtrashbackend.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.persistence.EntityManager;
+
 @Configuration
 @EnableJpaAuditing
-public class JpaConfig {}
+public class JpaConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Waste.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Waste.java
@@ -87,12 +87,6 @@ public class Waste extends AuditingAt implements Persistable<Long> {
     // TODO: transaction_logs와 연관 관계 설정
     // TODO: waste_likes와 연관 관계 설정
 
-    @PrePersist
-    private void prePersist() {
-        this.likeCount = 0;
-        this.viewCount = 0;
-    }
-
     @Builder
     private Waste(
             String title,

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
@@ -1,24 +1,30 @@
 package freshtrash.freshtrashbackend.repository;
 
+import com.querydsl.core.types.dsl.StringPath;
+import freshtrash.freshtrashbackend.entity.QWaste;
 import freshtrash.freshtrashbackend.entity.Waste;
-
+import freshtrash.freshtrashbackend.repository.custom.CustomWasteRepository;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 
 import java.util.Optional;
 
-public interface WasteRepository extends JpaRepository<Waste, Long> {
+public interface WasteRepository
+        extends JpaRepository<Waste, Long>, CustomWasteRepository, QuerydslBinderCustomizer<QWaste> {
+    @Override
+    default void customize(QuerydslBindings bindings, QWaste root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.title);
+        bindings.bind(String.class).first((StringPath path, String value) -> path.containsIgnoreCase(value));
+    }
 
     @EntityGraph(attributePaths = "member")
     Optional<Waste> findById(Long wasteId);
-
-    @EntityGraph(attributePaths = "member")
-    Page<Waste> findAll(Pageable pageable);
 
     Optional<FileNameSummary> findFileNameById(Long wasteId);
 

--- a/src/main/java/freshtrash/freshtrashbackend/repository/custom/CustomWasteRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/custom/CustomWasteRepository.java
@@ -1,0 +1,10 @@
+package freshtrash.freshtrashbackend.repository.custom;
+
+import com.querydsl.core.types.Predicate;
+import freshtrash.freshtrashbackend.entity.Waste;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomWasteRepository {
+    Page<Waste> findAll(String district, Predicate predicate, Pageable pageable);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/custom/CustomWasteRepositoryImpl.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/custom/CustomWasteRepositoryImpl.java
@@ -1,0 +1,39 @@
+package freshtrash.freshtrashbackend.repository.custom;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import freshtrash.freshtrashbackend.entity.QWaste;
+import freshtrash.freshtrashbackend.entity.Waste;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomWasteRepositoryImpl implements CustomWasteRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Waste> findAll(String district, Predicate predicate, Pageable pageable) {
+        List<Waste> wastes = jpaQueryFactory
+                .selectFrom(QWaste.waste)
+                .where(Expressions.booleanTemplate(
+                                "JSON_CONTAINS({0}, {1}, {2})",
+                                QWaste.waste.address,
+                                Expressions.stringTemplate("JSON_QUOTE({0})", district),
+                                "$.district")
+                        .isTrue().or(predicate))
+                .leftJoin(QWaste.waste.member)
+                .fetchJoin()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(wastes, pageable, wastes.size());
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -34,12 +34,10 @@ public class WasteService {
     private final WasteReviewRepository wasteReviewRepository;
     private final WasteLikeRepository wasteLikeRepository;
 
-    @Transactional(readOnly = true)
     public Waste getWasteEntity(Long wasteId) {
         return wasteRepository.findById(wasteId).orElseThrow(() -> new WasteException(ErrorCode.NOT_FOUND_WASTE));
     }
 
-    @Transactional(readOnly = true)
     public Page<WasteDto> getWastes(String district, Predicate predicate, Pageable pageable) {
         return wasteRepository.findAll(district, predicate, pageable).map(WasteDto::fromEntity);
     }
@@ -81,7 +79,6 @@ public class WasteService {
         fileService.deleteFileIfExists(savedFileName);
     }
 
-    @Transactional(readOnly = true)
     public FileNameSummary findFileNameOfWaste(Long wasteId) {
         return wasteRepository
                 .findFileNameById(wasteId)

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -1,14 +1,15 @@
 package freshtrash.freshtrashbackend.service;
 
+import com.querydsl.core.types.Predicate;
 import freshtrash.freshtrashbackend.dto.WasteDto;
+import freshtrash.freshtrashbackend.dto.constants.LikeStatus;
 import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Waste;
+import freshtrash.freshtrashbackend.entity.WasteLike;
 import freshtrash.freshtrashbackend.entity.WasteReview;
 import freshtrash.freshtrashbackend.exception.ReviewException;
-import freshtrash.freshtrashbackend.entity.WasteLike;
-import freshtrash.freshtrashbackend.dto.constants.LikeStatus;
 import freshtrash.freshtrashbackend.exception.WasteException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.WasteLikeRepository;
@@ -39,8 +40,8 @@ public class WasteService {
     }
 
     @Transactional(readOnly = true)
-    public Page<WasteDto> getWastes(Pageable pageable) {
-        return wasteRepository.findAll(pageable).map(WasteDto::fromEntity);
+    public Page<WasteDto> getWastes(String district, Predicate predicate, Pageable pageable) {
+        return wasteRepository.findAll(district, predicate, pageable).map(WasteDto::fromEntity);
     }
 
     public WasteDto addWaste(MultipartFile imgFile, WasteRequest wasteRequest, MemberPrincipal memberPrincipal) {
@@ -81,10 +82,9 @@ public class WasteService {
     }
 
     @Transactional(readOnly = true)
-    public String findFileNameOfWaste(Long wasteId) {
+    public FileNameSummary findFileNameOfWaste(Long wasteId) {
         return wasteRepository
                 .findFileNameById(wasteId)
-                .map(FileNameSummary::fileName)
                 .orElseThrow(() -> new WasteException(ErrorCode.NOT_FOUND_WASTE));
     }
 

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -11,3 +11,4 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        metadata_builder_contributor: freshtrash.freshtrashbackend.config.JSONMetadataBuilderContributor

--- a/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
+++ b/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
@@ -5,6 +5,7 @@ import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
 import freshtrash.freshtrashbackend.entity.constants.LoginType;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
+import freshtrash.freshtrashbackend.security.CustomOAuth2SuccessHandler;
 import freshtrash.freshtrashbackend.security.Http401UnauthorizedAuthenticationEntryPoint;
 import freshtrash.freshtrashbackend.security.SecurityConfig;
 import freshtrash.freshtrashbackend.security.TokenProvider;
@@ -26,6 +27,10 @@ public class TestSecurityConfig {
 
     @MockBean
     private Http401UnauthorizedAuthenticationEntryPoint http401UnauthorizedAuthenticationEntryPoint;
+
+    @MockBean
+    private CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+
 
     @BeforeTestMethod
     void securitySetUp() {

--- a/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
@@ -11,6 +11,7 @@ import freshtrash.freshtrashbackend.entity.Address;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.entity.constants.WasteCategory;
 import freshtrash.freshtrashbackend.entity.constants.WasteStatus;
+import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import freshtrash.freshtrashbackend.service.WasteService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -138,7 +139,7 @@ class WasteApiTest {
         WasteRequest wasteRequest = FixtureDto.createWasteRequest();
         WasteDto wasteDto = FixtureDto.createWasteDto();
         given(wasteService.isWriterOfArticle(wasteId, memberId)).willReturn(true);
-        given(wasteService.findFileNameOfWaste(anyLong())).willReturn("test.png");
+        given(wasteService.findFileNameOfWaste(anyLong())).willReturn(new FileNameSummary("test.png"));
         given(wasteService.updateWaste(
                         any(MultipartFile.class), any(WasteRequest.class), anyString(), any(MemberPrincipal.class)))
                 .willReturn(wasteDto);


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 폐기물 목록 페이지에서 제목, 주소(읍면동)으로 검색할 수 있도록 QueryDSL을 활용하여 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- QueryDSL Dependency 추가
- 폐기물 검색 쿼리
    - 제목 검색: `?title={검색 키워드}`
        - containsIgnoreCase를 적용
    - 읍면동(주소) 검색: `?district={검색 키워드}`
        - 검색 키워드와 일치해야함
- 주소 검색 쿼리
    - 콘솔에서 직접 쿼리를 요청하게 될 경우 다음과 같습니다.
        - `select * from wastes where JSON_CONTAINS(address, JSON_QUOTE('district'), '$.district');`
        - JSON_CONTAINS, JSON_QUOTE 함수가 필요하게되어 이를 `MetadataBuilderContributor` 구현체에서 등록했습니다
    - QueryDSL에서는 `booleanTemplate`을 사용하여 주소 검색 쿼리를 구현했습니다.
- hibernate sql log
    - where 절만 확인해보면 다음과 같이 출력됩니다.
        ```
        where
        JSON_CONTAINS(waste0_.address, JSON_QUOTE(?), ?)=? 
                or lower(waste0_.title) like ? escape '!' limit ?
        ```
- API 테스트
    <img width="1333" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/45a1d41b-b6eb-472d-8215-5537abbcf24b">


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- QueryDSL을 통해 생성되는 QClass들은 github에 올라가지 않도록 gitignore에 추가했습니다.
- Waste 엔티티에 조회수, 관심수 초기화 코드 삭제
    - 조회수, 관심수 타입을 primitive type으로 지정해주어 초기화 코드를 따로 작성하지 않아도 0으로 값이 초기화되기 때문에 삭제했습니다.
- 불필요한 Transactional 삭제

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #56 
