### PR TITLE
채팅 기능을 위한 Entity 와 Repository 추가

### DIFF
--- a/database/initdb.d/create_table.sql
+++ b/database/initdb.d/create_table.sql
@@ -1,16 +1,16 @@
 ﻿CREATE TABLE `members`
 (
     `id`             bigint AUTO_INCREMENT NOT NULL,
-    `email`          varchar(255) NOT NULL,
-    `password`       varchar(255) NOT NULL,
-    `rating`         double       NOT NULL,
-    `nickname`       varchar(255) NOT NULL,
+    `email`          varchar(255)          NOT NULL,
+    `password`       varchar(255)          NOT NULL,
+    `rating`         double                NOT NULL,
+    `nickname`       varchar(255)          NOT NULL,
     `address`        json,
     `file_name`      varchar(255),
-    `login_type`     varchar(255) NOT NULL,
-    `user_role`      varchar(255) NOT NULL,
-    `account_status` varchar(255) NOT NULL,
-    `created_at`     datetime     NOT NULL,
+    `login_type`     varchar(255)          NOT NULL,
+    `user_role`      varchar(255)          NOT NULL,
+    `account_status` varchar(255)          NOT NULL,
+    `created_at`     datetime              NOT NULL,
     `modified_at`    datetime,
     PRIMARY KEY (`id`),
     UNIQUE KEY (`email`),
@@ -22,18 +22,18 @@
 CREATE TABLE `wastes`
 (
     `id`             bigint AUTO_INCREMENT NOT NULL,
-    `member_id`      bigint       NOT NULL,
-    `title`          varchar(255) NOT NULL,
-    `content`        text         NOT NULL,
-    `waste_price`    integer      NOT NULL,
-    `like_count`     integer      NOT NULL,
-    `view_count`     integer      NOT NULL,
+    `member_id`      bigint                NOT NULL,
+    `title`          varchar(255)          NOT NULL,
+    `content`        text                  NOT NULL,
+    `waste_price`    integer               NOT NULL,
+    `like_count`     integer               NOT NULL,
+    `view_count`     integer               NOT NULL,
     `file_name`      varchar(255),
-    `waste_category` varchar(255) NOT NULL,
-    `waste_status`   varchar(255) NOT NULL,
-    `sell_status`    varchar(255) NOT NULL,
-    `address`        json         NOT NULL,
-    `created_at`     datetime     NOT NULL,
+    `waste_category` varchar(255)          NOT NULL,
+    `waste_status`   varchar(255)          NOT NULL,
+    `sell_status`    varchar(255)          NOT NULL,
+    `address`        json                  NOT NULL,
+    `created_at`     datetime              NOT NULL,
     `modified_at`    datetime,
     `transaction_at` datetime,
     PRIMARY KEY (`id`),
@@ -45,10 +45,10 @@ CREATE TABLE `wastes`
 CREATE TABLE `waste_reviews`
 (
     `id`         bigint AUTO_INCREMENT NOT NULL,
-    `member_id`  bigint   NOT NULL,
-    `waste_id`   bigint   NOT NULL,
-    `rating`     integer  NOT NULL,
-    `created_at` datetime NOT NULL,
+    `member_id`  bigint                NOT NULL,
+    `waste_id`   bigint                NOT NULL,
+    `rating`     integer               NOT NULL,
+    `created_at` datetime              NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`waste_id`) references wastes (id) on delete cascade
@@ -59,9 +59,9 @@ CREATE TABLE `waste_reviews`
 CREATE TABLE `waste_likes`
 (
     `id`         bigint AUTO_INCREMENT NOT NULL,
-    `member_id`  bigint   NOT NULL,
-    `waste_id`   bigint   NOT NULL,
-    `created_at` datetime NOT NULL,
+    `member_id`  bigint                NOT NULL,
+    `waste_id`   bigint                NOT NULL,
+    `created_at` datetime              NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`waste_id`) references wastes (id) on delete cascade
@@ -72,14 +72,14 @@ CREATE TABLE `waste_likes`
 CREATE UNIQUE INDEX member_id_and_waste_id ON waste_likes (member_id, waste_id);
 
 
-CREATE TABLE `chat_room`
+CREATE TABLE `chat_rooms`
 (
     `id`            bigint AUTO_INCREMENT NOT NULL,
-    `waste_id`      bigint   NOT NULL,
-    `seller_id`     bigint   NOT NULL,
-    `buyer_id`      bigint   NOT NULL,
-    `open_or_close` tinyint(1) NOT NULL,
-    `created_at`    datetime NOT NULL,
+    `waste_id`      bigint                NOT NULL,
+    `seller_id`     bigint                NOT NULL,
+    `buyer_id`      bigint                NOT NULL,
+    `open_or_close` tinyint(1)            NOT NULL,
+    `created_at`    datetime              NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`waste_id`) references `wastes` (`id`) on delete cascade,
     foreign key (`seller_id`) references `members` (`id`),
@@ -88,15 +88,15 @@ CREATE TABLE `chat_room`
   DEFAULT CHARSET = utf8mb4 COMMENT ='채팅방';
 
 
-CREATE TABLE `chat_message`
+CREATE TABLE `chat_messages`
 (
     `id`           bigint AUTO_INCREMENT NOT NULL,
-    `chat_room_id` bigint   NOT NULL,
-    `member_id`    bigint   NOT NULL,
-    `message`      TEXT     NOT NULL,
-    `created_at`   datetime NOT NULL,
+    `chat_room_id` bigint                NOT NULL,
+    `member_id`    bigint                NOT NULL,
+    `message`      TEXT                  NOT NULL,
+    `created_at`   datetime              NOT NULL,
     PRIMARY KEY (`id`),
-    foreign key (`chat_room_id`) references `chat_room` (`id`) on delete cascade,
+    foreign key (`chat_room_id`) references `chat_rooms` (`id`) on delete cascade,
     foreign key (`member_id`) references `members` (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='채팅 메세지';

--- a/database/initdb.d/create_table.sql
+++ b/database/initdb.d/create_table.sql
@@ -18,6 +18,7 @@
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='멤버';
 
+
 CREATE TABLE `wastes`
 (
     `id`             bigint AUTO_INCREMENT NOT NULL,
@@ -54,6 +55,7 @@ CREATE TABLE `waste_reviews`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='폐기물 리뷰';
 
+
 CREATE TABLE `waste_likes`
 (
     `id`         bigint AUTO_INCREMENT NOT NULL,
@@ -66,7 +68,9 @@ CREATE TABLE `waste_likes`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='관심 폐기물';
 
+
 CREATE UNIQUE INDEX member_id_and_waste_id ON waste_likes (member_id, waste_id);
+
 
 CREATE TABLE `chat_room`
 (
@@ -82,3 +86,17 @@ CREATE TABLE `chat_room`
     foreign key (`buyer_id`) references `members` (`id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='채팅방';
+
+
+CREATE TABLE `chat_message`
+(
+    `id`           bigint AUTO_INCREMENT NOT NULL,
+    `chat_room_id` bigint   NOT NULL,
+    `member_id`    bigint   NOT NULL,
+    `message`      TEXT     NOT NULL,
+    `created_at`   datetime NOT NULL,
+    PRIMARY KEY (`id`),
+    foreign key (`chat_room_id`) references `chat_room` (`id`) on delete cascade,
+    foreign key (`member_id`) references `members` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='채팅 메세지';

--- a/database/initdb.d/create_table.sql
+++ b/database/initdb.d/create_table.sql
@@ -1,16 +1,16 @@
 ﻿CREATE TABLE `members`
 (
     `id`             bigint AUTO_INCREMENT NOT NULL,
-    `email`          varchar(255)          NOT NULL,
-    `password`       varchar(255)          NOT NULL,
-    `rating`         double                NOT NULL,
-    `nickname`       varchar(255)          NOT NULL,
+    `email`          varchar(255) NOT NULL,
+    `password`       varchar(255) NOT NULL,
+    `rating`         double       NOT NULL,
+    `nickname`       varchar(255) NOT NULL,
     `address`        json,
     `file_name`      varchar(255),
-    `login_type`     varchar(255)          NOT NULL,
-    `user_role`      varchar(255)          NOT NULL,
-    `account_status` varchar(255)          NOT NULL,
-    `created_at`     datetime              NOT NULL,
+    `login_type`     varchar(255) NOT NULL,
+    `user_role`      varchar(255) NOT NULL,
+    `account_status` varchar(255) NOT NULL,
+    `created_at`     datetime     NOT NULL,
     `modified_at`    datetime,
     PRIMARY KEY (`id`),
     UNIQUE KEY (`email`),
@@ -21,18 +21,18 @@
 CREATE TABLE `wastes`
 (
     `id`             bigint AUTO_INCREMENT NOT NULL,
-    `member_id`      bigint                NOT NULL,
-    `title`          varchar(255)          NOT NULL,
-    `content`        text                  NOT NULL,
-    `waste_price`    integer               NOT NULL,
-    `like_count`     integer               NOT NULL,
-    `view_count`     integer               NOT NULL,
+    `member_id`      bigint       NOT NULL,
+    `title`          varchar(255) NOT NULL,
+    `content`        text         NOT NULL,
+    `waste_price`    integer      NOT NULL,
+    `like_count`     integer      NOT NULL,
+    `view_count`     integer      NOT NULL,
     `file_name`      varchar(255),
-    `waste_category` varchar(255)          NOT NULL,
-    `waste_status`   varchar(255)          NOT NULL,
-    `sell_status`    varchar(255)          NOT NULL,
-    `address`        json                  NOT NULL,
-    `created_at`     datetime              NOT NULL,
+    `waste_category` varchar(255) NOT NULL,
+    `waste_status`   varchar(255) NOT NULL,
+    `sell_status`    varchar(255) NOT NULL,
+    `address`        json         NOT NULL,
+    `created_at`     datetime     NOT NULL,
     `modified_at`    datetime,
     `transaction_at` datetime,
     PRIMARY KEY (`id`),
@@ -44,10 +44,10 @@ CREATE TABLE `wastes`
 CREATE TABLE `waste_reviews`
 (
     `id`         bigint AUTO_INCREMENT NOT NULL,
-    `member_id`  bigint                NOT NULL,
-    `waste_id`   bigint                NOT NULL,
-    `rating`     integer               NOT NULL,
-    `created_at` datetime              NOT NULL,
+    `member_id`  bigint   NOT NULL,
+    `waste_id`   bigint   NOT NULL,
+    `rating`     integer  NOT NULL,
+    `created_at` datetime NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`waste_id`) references wastes (id) on delete cascade
@@ -57,9 +57,9 @@ CREATE TABLE `waste_reviews`
 CREATE TABLE `waste_likes`
 (
     `id`         bigint AUTO_INCREMENT NOT NULL,
-    `member_id`  bigint                NOT NULL,
-    `waste_id`   bigint                NOT NULL,
-    `created_at` datetime              NOT NULL,
+    `member_id`  bigint   NOT NULL,
+    `waste_id`   bigint   NOT NULL,
+    `created_at` datetime NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`waste_id`) references wastes (id) on delete cascade
@@ -67,3 +67,18 @@ CREATE TABLE `waste_likes`
   DEFAULT CHARSET = utf8mb4 COMMENT ='관심 폐기물';
 
 CREATE UNIQUE INDEX member_id_and_waste_id ON waste_likes (member_id, waste_id);
+
+CREATE TABLE `chat_room`
+(
+    `id`            bigint AUTO_INCREMENT NOT NULL,
+    `waste_id`      bigint   NOT NULL,
+    `seller_id`     bigint   NOT NULL,
+    `buyer_id`      bigint   NOT NULL,
+    `open_or_close` tinyint(1) NOT NULL,
+    `created_at`    datetime NOT NULL,
+    PRIMARY KEY (`id`),
+    foreign key (`waste_id`) references `wastes` (`id`) on delete cascade,
+    foreign key (`seller_id`) references `members` (`id`),
+    foreign key (`buyer_id`) references `members` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='채팅방';

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -21,3 +21,6 @@ values (1, 'title', 'content', 0, 1, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING
 
 insert into waste_likes(member_id, waste_id, created_at)
 values (2, 1, now());
+
+INSERT INTO `chat_room`(`waste_id`, `seller_id`, `buyer_id`, `open_or_close`, created_at)
+VALUES (1, 1, 2, 1, now());

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -7,7 +7,6 @@ values ('abc@never.com', '$2a$10$4mbVj4n1KeBmNsQCeXZpZujVo.cmXMdPIoDUQ1c1jkR87Ld
         null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null);
 
 
-
 insert into wastes(member_id, title, content, waste_price, like_count, view_count, file_name, waste_category,
                    waste_status,
                    sell_status, address, created_at, modified_at, transaction_at)
@@ -22,5 +21,10 @@ values (1, 'title', 'content', 0, 1, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING
 insert into waste_likes(member_id, waste_id, created_at)
 values (2, 1, now());
 
+
 INSERT INTO `chat_room`(`waste_id`, `seller_id`, `buyer_id`, `open_or_close`, created_at)
 VALUES (1, 1, 2, 1, now());
+
+
+INSERT INTO `chat_message`(`chat_room_id`, `member_id`, `message`, `created_at`)
+VALUES (1, 1, '첫 번째 메세지입니다.', now());

--- a/database/initdb.d/insert_data.sql
+++ b/database/initdb.d/insert_data.sql
@@ -22,9 +22,9 @@ insert into waste_likes(member_id, waste_id, created_at)
 values (2, 1, now());
 
 
-INSERT INTO `chat_room`(`waste_id`, `seller_id`, `buyer_id`, `open_or_close`, created_at)
+INSERT INTO chat_rooms(`waste_id`, `seller_id`, `buyer_id`, `open_or_close`, created_at)
 VALUES (1, 1, 2, 1, now());
 
 
-INSERT INTO `chat_message`(`chat_room_id`, `member_id`, `message`, `created_at`)
+INSERT INTO chat_messages(`chat_room_id`, `member_id`, `message`, `created_at`)
 VALUES (1, 1, '첫 번째 메세지입니다.', now());

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
@@ -2,9 +2,12 @@ package freshtrash.freshtrashbackend.entity;
 
 import freshtrash.freshtrashbackend.entity.audit.AuditingAt;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.Persistable;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "chat_message")
@@ -12,14 +15,14 @@ import javax.persistence.*;
 @ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class ChatMessage extends AuditingAt implements Persistable<Long> {
+public class ChatMessage implements Persistable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id", nullable = false)
+    @JoinColumn(name = "chatRoomId", insertable = false, updatable = false)
     private ChatRoom chatRoom;
 
     @Column(nullable = false)
@@ -35,6 +38,11 @@ public class ChatMessage extends AuditingAt implements Persistable<Long> {
 
     @Column(name = "message", nullable = false, columnDefinition = "TEXT")
     private String message;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     @Builder
     public ChatMessage(Long chatRoomId, Long memberId, String message) {

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
@@ -2,6 +2,7 @@ package freshtrash.freshtrashbackend.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EntityListeners(AuditingEntityListener.class)
 public class ChatMessage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
@@ -1,0 +1,50 @@
+package freshtrash.freshtrashbackend.entity;
+
+import freshtrash.freshtrashbackend.entity.audit.AuditingAt;
+import lombok.*;
+import org.springframework.data.domain.Persistable;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@ToString(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class ChatMessage extends AuditingAt implements Persistable<Long> {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Column(nullable = false)
+    private Long chatRoomId;
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId", insertable = false, updatable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Builder
+    public ChatMessage(Long chatRoomId, Long memberId, String message) {
+        this.chatRoomId = chatRoomId;
+        this.memberId = memberId;
+        this.message = message;
+    }
+
+    @Override
+    public boolean isNew() {
+        return id == null;
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
@@ -2,19 +2,18 @@ package freshtrash.freshtrashbackend.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.domain.Persistable;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "chat_message")
+@Table(name = "chat_messages")
 @Getter
-@ToString(callSuper = true)
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class ChatMessage implements Persistable<Long> {
+public class ChatMessage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include
@@ -35,7 +34,7 @@ public class ChatMessage implements Persistable<Long> {
     @Column(nullable = false)
     private Long memberId;
 
-    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String message;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
@@ -43,15 +42,13 @@ public class ChatMessage implements Persistable<Long> {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Builder
     public ChatMessage(Long chatRoomId, Long memberId, String message) {
         this.chatRoomId = chatRoomId;
         this.memberId = memberId;
         this.message = message;
     }
 
-    @Override
-    public boolean isNew() {
-        return id == null;
+    public static ChatMessage of(Long chatRoomId, Long memberId, String message) {
+        return new ChatMessage(chatRoomId, memberId, message);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatMessage.java
@@ -1,6 +1,5 @@
 package freshtrash.freshtrashbackend.entity;
 
-import freshtrash.freshtrashbackend.entity.audit.AuditingAt;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.Persistable;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
@@ -1,0 +1,50 @@
+package freshtrash.freshtrashbackend.entity;
+
+import freshtrash.freshtrashbackend.entity.audit.AuditingAt;
+import lombok.*;
+import org.springframework.data.domain.Persistable;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "chat_room")
+@Getter
+@ToString(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class ChatRoom extends AuditingAt implements Persistable<Long> {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "waste_id", nullable = false)
+    private Waste waste;
+
+    @Column(nullable = false)
+    private Long wasteId;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "buyer_id", nullable = false)
+    private Long buyerId;
+
+    @Column(name = "open_or_close", nullable = false)
+    private boolean openOrClose;
+
+    @Builder
+    public ChatRoom(Long wasteId, Long sellerId, Long buyerId, boolean openOrClose) {
+        this.wasteId = wasteId;
+        this.sellerId = sellerId;
+        this.buyerId = buyerId;
+        this.openOrClose = openOrClose;
+    }
+
+    @Override
+    public boolean isNew() {
+        return id == null;
+    }
+}
+

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
@@ -1,6 +1,5 @@
 package freshtrash.freshtrashbackend.entity;
 
-import freshtrash.freshtrashbackend.entity.audit.AuditingAt;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.Persistable;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
@@ -2,9 +2,12 @@ package freshtrash.freshtrashbackend.entity;
 
 import freshtrash.freshtrashbackend.entity.audit.AuditingAt;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.Persistable;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "chat_room")
@@ -12,14 +15,14 @@ import javax.persistence.*;
 @ToString(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class ChatRoom extends AuditingAt implements Persistable<Long> {
+public class ChatRoom implements Persistable<Long> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "waste_id", nullable = false)
+    @JoinColumn(name = "wasteId", insertable = false, updatable = false)
     private Waste waste;
 
     @Column(nullable = false)
@@ -34,6 +37,11 @@ public class ChatRoom extends AuditingAt implements Persistable<Long> {
     @Column(name = "open_or_close", nullable = false)
     private boolean openOrClose;
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
     @Builder
     public ChatRoom(Long wasteId, Long sellerId, Long buyerId, boolean openOrClose) {
         this.wasteId = wasteId;
@@ -47,4 +55,3 @@ public class ChatRoom extends AuditingAt implements Persistable<Long> {
         return id == null;
     }
 }
-

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
@@ -2,23 +2,30 @@ package freshtrash.freshtrashbackend.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.domain.Persistable;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "chat_room")
+@Table(name = "chat_rooms")
 @Getter
-@ToString(callSuper = true)
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class ChatRoom implements Persistable<Long> {
+public class ChatRoom {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include
     private Long id;
+
+    @Column(nullable = false)
+    private boolean openOrClose;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "wasteId", insertable = false, updatable = false)
@@ -27,19 +34,21 @@ public class ChatRoom implements Persistable<Long> {
     @Column(nullable = false)
     private Long wasteId;
 
-    @Column(name = "seller_id", nullable = false)
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sellerId", insertable = false, updatable = false)
+    private Member seller;
+
+    @Column(nullable = false)
     private Long sellerId;
 
-    @Column(name = "buyer_id", nullable = false)
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "buyerId", insertable = false, updatable = false)
+    private Member buyer;
+
+    @Column(nullable = false)
     private Long buyerId;
-
-    @Column(name = "open_or_close", nullable = false)
-    private boolean openOrClose;
-
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
 
     @Builder
     public ChatRoom(Long wasteId, Long sellerId, Long buyerId, boolean openOrClose) {
@@ -47,10 +56,5 @@ public class ChatRoom implements Persistable<Long> {
         this.sellerId = sellerId;
         this.buyerId = buyerId;
         this.openOrClose = openOrClose;
-    }
-
-    @Override
-    public boolean isNew() {
-        return id == null;
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
@@ -2,6 +2,7 @@ package freshtrash.freshtrashbackend.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EntityListeners(AuditingEntityListener.class)
 public class ChatRoom {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatMessageRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatMessageRepository.java
@@ -1,0 +1,10 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}
+

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatMessageRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatMessageRepository.java
@@ -5,6 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-}
-
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatMessageRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatMessageRepository.java
@@ -4,5 +4,4 @@ import freshtrash.freshtrashbackend.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -4,5 +4,4 @@ import freshtrash.freshtrashbackend.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -1,4 +1,8 @@
-package freshtrash.freshtrashbackend.repository.projections;
+package freshtrash.freshtrashbackend.repository;
 
-public interface ChatRoomRepository {
-}
+import freshtrash.freshtrashbackend.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -1,0 +1,4 @@
+package freshtrash.freshtrashbackend.repository.projections;
+
+public interface ChatRoomRepository {
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
채팅 기능에서 사용될 기본 엔티티와 레파지토리를 추가합니다. 

## ✨ 이 PR에서 핵심적으로 변경된 사항
- `chat_message` 엔티티 설계
- `chat_room` 엔티티 설계
- `ChatMessageRepository` 인터페이스 추가
- `ChatRoomRepository` 인터페이스 추가
- DB 테이블의 생성 및 데이터 추가
  - create_table.sql 파일에 chat_message, chat_room 테이블을 생성하기 위한 SQL문을 작성합니다.
  - insert_data.sql 파일에 위에서 생성한 테이블에 데이터를 추가하기 위한 SQL문을 작성합니다.
  - 도커를 사용하여 데이터베이스를 실행하는 컨테이너 안에서 터미널을 열어, 데이터가 성공적으로 추가되었는지 확인합니다.
![스크린샷 2024-04-14 오전 1 04 24](https://github.com/fresh-trash-project/fresh-trash-backend/assets/98696925/80ef9185-6687-409f-8eb8-100ef5001d25)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
없음

## Issue Tags
- Closed : #61

