### PR TITLE
member 정보 수정 기능 

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuthApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuthApi.java
@@ -24,7 +24,7 @@ public class AuthApi {
      * 회원가입
      */
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody @Valid SignUpRequest signUpRequest) {
+    public ResponseEntity<ApiResponse<String>> signup(@RequestBody @Valid SignUpRequest signUpRequest) {
         memberService.registerMember(signUpRequest.toEntity());
         return ResponseEntity.ok(ApiResponse.of("you're successfully sign up. you can be login."));
     }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuthApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuthApi.java
@@ -6,11 +6,9 @@ import freshtrash.freshtrashbackend.dto.response.ApiResponse;
 import freshtrash.freshtrashbackend.dto.response.LoginResponse;
 import freshtrash.freshtrashbackend.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -26,7 +24,8 @@ public class AuthApi {
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<String>> signup(@RequestBody @Valid SignUpRequest signUpRequest) {
         memberService.registerMember(signUpRequest.toEntity());
-        return ResponseEntity.ok(ApiResponse.of("you're successfully sign up. you can be login."));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of("you're successfully sign up. you can be login."));
     }
 
     /**
@@ -36,5 +35,14 @@ public class AuthApi {
     public ResponseEntity<LoginResponse> signIn(@RequestBody @Valid LoginRequest loginRequest) {
         LoginResponse loginResponse = memberService.signIn(loginRequest.email(), loginRequest.password());
         return ResponseEntity.ok(loginResponse);
+    }
+
+    /**
+     * 닉네임 중복확인
+     */
+    @GetMapping("/check-nickname/{nickname}")
+    public ResponseEntity<ApiResponse<String>> checkNickname(@PathVariable String nickname) {
+        memberService.checkNicknameDuplication(nickname);
+        return ResponseEntity.ok(ApiResponse.of("사용가능한 닉네임입니다."));
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/MailApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/MailApi.java
@@ -4,6 +4,7 @@ import freshtrash.freshtrashbackend.dto.request.EmailRequest;
 import freshtrash.freshtrashbackend.dto.response.ApiResponse;
 import freshtrash.freshtrashbackend.dto.response.EmailResponse;
 import freshtrash.freshtrashbackend.service.MailService;
+import freshtrash.freshtrashbackend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -21,13 +22,15 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class MailApi {
     private final MailService mailService;
+    private final MemberService memberService;
 
     /**
      * 인증코드 메일 발송
      */
     @PostMapping("/send-code")
     public ResponseEntity<EmailResponse> sendMailWithCode(@RequestBody @Valid EmailRequest request) {
-        // TODO 중복된 이메일 체크
+        memberService.checkEmailDuplication(request.email());
+
         String code = UUID.randomUUID().toString().substring(0, 8);
         String subject = "fresh-trash 메일 인증";
         mailService.sendMailWithCode(request.email(), subject, code);

--- a/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
@@ -1,6 +1,8 @@
 package freshtrash.freshtrashbackend.controller;
 
 import freshtrash.freshtrashbackend.dto.UserInfo;
+import freshtrash.freshtrashbackend.dto.response.MemberResponse;
+import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +10,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import freshtrash.freshtrashbackend.dto.request.MemberRequest;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -19,8 +24,19 @@ public class MemberApi {
      * 유저 정보 조회
      */
     @GetMapping("/{memberId}")
-    public ResponseEntity<UserInfo> getMember(@PathVariable Long memberId) {
-        UserInfo userInfo = UserInfo.fromEntity(memberService.getMemberEntity(memberId));
-        return ResponseEntity.ok(userInfo);
+    public ResponseEntity<MemberResponse> getMember(@PathVariable Long memberId) {
+        MemberResponse memberResponse = MemberResponse.fromEntity(memberService.getMemberEntity(memberId));
+        return ResponseEntity.ok(memberResponse);
+    }
+
+    /**
+     * 유저 정보 수정
+     */
+    @PutMapping("/{memberId}")
+    public ResponseEntity<MemberResponse> updateMember(
+            @PathVariable Long memberId, @RequestPart MemberRequest memberRequest, @RequestPart MultipartFile imgFile) {
+        MemberResponse memberResponse =
+                MemberResponse.fromEntity(memberService.updateMember(memberId, memberRequest, imgFile));
+        return ResponseEntity.ok(memberResponse);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
@@ -1,11 +1,12 @@
 package freshtrash.freshtrashbackend.controller;
 
 import freshtrash.freshtrashbackend.dto.response.MemberResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import freshtrash.freshtrashbackend.dto.request.MemberRequest;
@@ -21,20 +22,22 @@ public class MemberApi {
     /**
      * 유저 정보 조회
      */
-    @GetMapping("/{memberId}")
-    public ResponseEntity<MemberResponse> getMember(@PathVariable Long memberId) {
-        MemberResponse memberResponse = MemberResponse.fromEntity(memberService.getMemberEntity(memberId));
+    @GetMapping()
+    public ResponseEntity<MemberResponse> getMember(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        MemberResponse memberResponse = MemberResponse.fromEntity(memberService.getMemberEntity(memberPrincipal.id()));
         return ResponseEntity.ok(memberResponse);
     }
 
     /**
      * 유저 정보 수정
      */
-    @PutMapping("/{memberId}")
+    @PutMapping()
     public ResponseEntity<MemberResponse> updateMember(
-            @PathVariable Long memberId, @RequestPart MemberRequest memberRequest, @RequestPart MultipartFile imgFile) {
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @RequestPart MemberRequest memberRequest,
+            @RequestPart MultipartFile imgFile) {
         MemberResponse memberResponse =
-                MemberResponse.fromEntity(memberService.updateMember(memberId, memberRequest, imgFile));
+                MemberResponse.fromEntity(memberService.updateMember(memberPrincipal.id(), memberRequest, imgFile));
         return ResponseEntity.ok(memberResponse);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
@@ -1,8 +1,6 @@
 package freshtrash.freshtrashbackend.controller;
 
-import freshtrash.freshtrashbackend.dto.UserInfo;
 import freshtrash.freshtrashbackend.dto.response.MemberResponse;
-import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/MemberRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/MemberRequest.java
@@ -1,0 +1,7 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+import freshtrash.freshtrashbackend.entity.Address;
+
+import javax.validation.constraints.NotBlank;
+
+public record MemberRequest(@NotBlank String nickname, Address address) {}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/MemberResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/MemberResponse.java
@@ -1,0 +1,31 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+import freshtrash.freshtrashbackend.entity.Address;
+import freshtrash.freshtrashbackend.entity.Member;
+import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
+import freshtrash.freshtrashbackend.entity.constants.LoginType;
+import lombok.Builder;
+
+@Builder
+public record MemberResponse(
+        Long id,
+        String email,
+        String nickname,
+        double rating,
+        String fileName,
+        Address address,
+        LoginType loginType,
+        AccountStatus accountStatus) {
+    public static MemberResponse fromEntity(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .rating(member.getRating())
+                .fileName(member.getFileName())
+                .address(member.getAddress())
+                .loginType(member.getLoginType())
+                .accountStatus(member.getAccountStatus())
+                .build();
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/MemberResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/MemberResponse.java
@@ -2,30 +2,16 @@ package freshtrash.freshtrashbackend.dto.response;
 
 import freshtrash.freshtrashbackend.entity.Address;
 import freshtrash.freshtrashbackend.entity.Member;
-import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
-import freshtrash.freshtrashbackend.entity.constants.LoginType;
 import lombok.Builder;
 
 @Builder
-public record MemberResponse(
-        Long id,
-        String email,
-        String nickname,
-        double rating,
-        String fileName,
-        Address address,
-        LoginType loginType,
-        AccountStatus accountStatus) {
+public record MemberResponse(String nickname, double rating, String fileName, Address address) {
     public static MemberResponse fromEntity(Member member) {
         return MemberResponse.builder()
-                .id(member.getId())
-                .email(member.getEmail())
                 .nickname(member.getNickname())
                 .rating(member.getRating())
                 .fileName(member.getFileName())
                 .address(member.getAddress())
-                .loginType(member.getLoginType())
-                .accountStatus(member.getAccountStatus())
                 .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -40,13 +40,16 @@ public class Member extends AuditingAt implements Persistable<Long> {
     @Column(nullable = false)
     private double rating;
 
+    @Setter
     @Column(nullable = false, unique = true)
     private String nickname;
 
+    @Setter
     @Type(type = "json")
     @Column(columnDefinition = "longtext")
     private Address address;
 
+    @Setter
     @Column
     private String fileName;
 
@@ -67,7 +70,15 @@ public class Member extends AuditingAt implements Persistable<Long> {
     private Set<Waste> wastes = new LinkedHashSet<>();
 
     @Builder // 빌더 패턴 적용
-    public Member(String email, String password, String nickname, Address address, String fileName, LoginType loginType, UserRole userRole, AccountStatus accountStatus) {
+    public Member(
+            String email,
+            String password,
+            String nickname,
+            Address address,
+            String fileName,
+            LoginType loginType,
+            UserRole userRole,
+            AccountStatus accountStatus) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
@@ -32,12 +32,8 @@ public class MemberService {
      * 회원 가입
      */
     public void registerMember(Member member) {
-        if (checkEmailDuplication(member.getEmail())) {
-            throw new MemberException(ErrorCode.ALREADY_EXISTS_EMAIL);
-        }
-        if (checkNicknameDuplication(member.getNickname())) {
-            throw new MemberException(ErrorCode.ALREADY_EXISTS_NICKNAME);
-        }
+        checkEmailDuplication(member.getEmail());
+        checkNicknameDuplication(member.getNickname());
         member.setPassword(encoder.encode(member.getPassword()));
         memberRepository.save(member);
     }
@@ -56,15 +52,19 @@ public class MemberService {
     /**
      * 이메일 중복 체크
      */
-    public boolean checkEmailDuplication(String email) {
-        return memberRepository.existsByEmail(email);
+    public void checkEmailDuplication(String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new MemberException(ErrorCode.ALREADY_EXISTS_EMAIL);
+        }
     }
 
     /**
-     * 닉네임 중복확인
+     * 닉네임 중복 체크
      */
-    public boolean checkNicknameDuplication(String nickname) {
-        return memberRepository.existsByNickname(nickname);
+    public void checkNicknameDuplication(String nickname) {
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new MemberException(ErrorCode.ALREADY_EXISTS_NICKNAME);
+        }
     }
 
     /**
@@ -99,13 +99,11 @@ public class MemberService {
     }
 
     public Member updateMember(Long memberId, MemberRequest memberRequest, MultipartFile imgFile) {
+        checkNicknameDuplication(memberRequest.nickname());
+
         String updatedFileName = FileUtils.generateUniqueFileName(imgFile);
         Member member =
                 memberRepository.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
-
-        if (checkNicknameDuplication(memberRequest.nickname())) {
-            throw new MemberException(ErrorCode.ALREADY_EXISTS_NICKNAME);
-        }
 
         // 파일은 유효할 경우에만 수정
         if (FileUtils.isValid(imgFile)) {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 사용자 정보를 수정하는 기능입니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- memberResponse 생성 
- member 정보 수정시
  - 중복된 닉네임이면 수정되지 않습니다. 
  - 프로필 파일이 유효하지 않으면 프로필 파일 제외하고 닉네임, 주소는 수정됩니다. 
  - 프로필 파일이 수정되면 기존의 파일은 삭제됩니다.
- member ID는 token정보로 받아옵니다. 

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 회원가입 기능에서 와일드카드 쓴것 수정 
- 회원가입 기능에서 TODO로 있던 이메일 중복체크 추가 
- GetMapping 닉네임 중복 체크 기능 추가 

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed : #55 
