### PR TITLE
메일 유효성 검증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     //queryDSL
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+    
+    //gson
+    implementation 'com.google.code.gson:gson:2.10.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/freshtrash/freshtrashbackend/dto/properties/MailProperties.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/properties/MailProperties.java
@@ -1,0 +1,9 @@
+package freshtrash.freshtrashbackend.dto.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+import javax.validation.constraints.NotBlank;
+
+@Validated
+@ConfigurationProperties(prefix = "validation")
+public record MailProperties(@NotBlank String apiKey) {}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
     AUTH_CODE_UNMATCHED(HttpStatus.BAD_REQUEST, "잘못된 인증코드입니다."),
     EMPTY_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증코드가 입력되지 않았습니다."),
     MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일전송에 실패했습니다"),
+    MAIL_VALIDATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일검증에 실패했습니다."),
+    MAIL_NOT_VALID(HttpStatus.BAD_REQUEST, "유효하지 않은 메일입니다."),
 
     // Member
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "유저 정보가 존재하지 않습니다."),

--- a/src/main/java/freshtrash/freshtrashbackend/service/MailService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MailService.java
@@ -82,14 +82,14 @@ public class MailService {
             String result = response.body();
             JsonObject jsonObject = JsonParser.parseString(result).getAsJsonObject();
             String deliverable = jsonObject.get("deliverability").getAsString();
-            System.out.println(deliverable);
+
             boolean isFree = jsonObject
                     .get("is_free_email")
                     .getAsJsonObject()
                     .get("value")
                     .getAsBoolean();
 
-            if (deliverable.equals("UNDELIVERABLE") || !isFree) {
+            if (!deliverable.equals("DELIVERABLE") || !isFree) {
                 throw new MailException(ErrorCode.MAIL_NOT_VALID);
             }
 

--- a/src/main/java/freshtrash/freshtrashbackend/service/MailService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MailService.java
@@ -1,5 +1,8 @@
 package freshtrash.freshtrashbackend.service;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import freshtrash.freshtrashbackend.dto.properties.MailProperties;
 import freshtrash.freshtrashbackend.exception.MailException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +13,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 @Slf4j
 @Service
@@ -17,11 +25,13 @@ import javax.mail.internet.MimeMessage;
 public class MailService {
     private final JavaMailSender mailSender;
     private final RedisService redisService;
+    private final MailProperties mailProperties;
     private final int AUTH_CODE_DURATION_MIN = 10;
     private final int AUTH_SUCCESS_DURATION_MIN = 300;
     private final String AUTH_SUCCESS = "AuthSuccess";
 
     public void sendMailWithCode(String email, String subject, String code) {
+        isValidMail(email);
         String text = "fresh-trash 메일 인증 코드입니다. <br/>인증코드:" + code;
         sendMail(email, subject, text);
         redisService.saveEmailVerificationCode(email, code, AUTH_CODE_DURATION_MIN);
@@ -54,6 +64,37 @@ public class MailService {
             mailSender.send(mimeMessage);
         } catch (Exception e) {
             throw new MailException(ErrorCode.MAIL_SEND_FAIL, e);
+        }
+    }
+
+    /**
+     * 메일 유효성 검증
+     */
+    private void isValidMail(String email) {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://emailvalidation.abstractapi.com/v1/?api_key=" + mailProperties.apiKey()
+                        + "&email=" + email))
+                .build();
+
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            String result = response.body();
+            JsonObject jsonObject = JsonParser.parseString(result).getAsJsonObject();
+            String deliverable = jsonObject.get("deliverability").getAsString();
+            System.out.println(deliverable);
+            boolean isFree = jsonObject
+                    .get("is_free_email")
+                    .getAsJsonObject()
+                    .get("value")
+                    .getAsBoolean();
+
+            if (deliverable.equals("UNDELIVERABLE") || !isFree) {
+                throw new MailException(ErrorCode.MAIL_NOT_VALID);
+            }
+
+        } catch (IOException | InterruptedException e) {
+            throw new MailException(ErrorCode.MAIL_VALIDATION_FAIL, e);
         }
     }
 }

--- a/src/main/resources/application-mail.yml
+++ b/src/main/resources/application-mail.yml
@@ -16,3 +16,6 @@ spring:
     redis:
       host: 127.0.0.1
       port: 6379
+
+validation:
+  api-key: ${API_KEY}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 인증코드 메일을 보내기전 메일이 유효한지 검증하는 기능입니다.
- 처음엔 mailgun api를 사용하려 살펴봤는데 무료버전으로는 임의 메일로 전송이 안되고, 등록해둔 메일로만 전송가능해서 [mail validation api](https://www.abstractapi.com/api/email-verification-validation-api) 를 사용하여 유효성을 검증하고, 메일 보내는 것은 기존 방법 그대로 두었습니다. 
- validation api의 반환값 중 이메일 전달 가능성을 나타내는 deliverability(DELIVERABLE, UNDELIVERABLE, UNKNOWN) 과 이메일의 도메인이 Abstract의 무료 이메일 제공업체에 등록되어있는지 여부인 is_free_email(true, false) 를 가지고 deliverability=DELIVERABLE 이면서 is_free_email=true 값일때 유효하다 판단합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- api_key는 노션 .env파일에 적어뒀습니다
- jsonObject파싱을 위해 gradle에 gson을 추가했습니다.
- 인증메일 보내기전 isValidMail 수행 
- api test
<img width="1349" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/82129206/7d6ea47a-7c70-441c-94f1-55636161b795">
인증코드 발송api에서 이메일 검증시 유효하지 않으면 위와 같이 예외처리됩니다.

- test case
- freshtrash@naver.com : deliverability= UNDELIVERABLE, is_free_email = true
- freshtrash@**naverr**.com : deliverability= UNDELIVERABLE, is_free_email = false
- 12332423@gmail.com : deliverability= UNDELIVERABLE, is_free_email = true
- haha007@**navsr**.com : deliverability= DELIVERABLE, is_free_email = false

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed : #60 
