### PR TITLE
알람 읽음 처리 요청 API 구현

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
@@ -2,6 +2,8 @@ package freshtrash.freshtrashbackend.controller;
 
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.exception.AlarmException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.service.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -10,6 +12,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -36,5 +39,23 @@ public class AlarmApi {
     @GetMapping("/subscribe")
     public ResponseEntity<SseEmitter> subscribe(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         return ResponseEntity.ok(alarmService.connectAlarm(memberPrincipal.id()));
+    }
+
+    /**
+     * 알람 읽음 처리 요청
+     */
+    @GetMapping("/{alarmId}")
+    public ResponseEntity<Void> readAlarm(
+            @PathVariable Long alarmId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        checkIfOwnerOfAlarm(alarmId, memberPrincipal.id());
+        alarmService.readAlarm(alarmId);
+        return ResponseEntity.ok(null);
+    }
+
+    /**
+     * 로그인한 사용자가 대상 알람의 주인인지 확인
+     */
+    private void checkIfOwnerOfAlarm(Long alarmId, Long memberId) {
+        if (!alarmService.isOwnerOfAlarm(alarmId, memberId)) throw new AlarmException(ErrorCode.FORBIDDEN_ALARM);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
 
     // Alarm
-    ALARM_CONNECT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알람을 위한 연결 시도 실패");
+    ALARM_CONNECT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알람을 위한 연결 시도 실패"),
+    FORBIDDEN_ALARM(HttpStatus.FORBIDDEN, "알람에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
@@ -4,7 +4,15 @@ import freshtrash.freshtrashbackend.entity.Alarm;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Page<Alarm> findAllByMember_IdAndReadAtIsNull(Long memberId, Pageable pageable);
+
+    @Query(nativeQuery = true, value = "update alarms a set a.read_at = now() where a.id = ?1")
+    void updateReadAtById(Long alarmId);
+
+
+    boolean existsByIdAndMember_Id(Long alarmId, Long memberId);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -116,4 +116,12 @@ public class AlarmService {
 
         return sseEmitter;
     }
+
+    public void readAlarm(Long alarmId) {
+        alarmRepository.updateReadAtById(alarmId);
+    }
+
+    public boolean isOwnerOfAlarm(Long alarmId, Long memberId) {
+        return alarmRepository.existsByIdAndMember_Id(alarmId, memberId);
+    }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AlarmApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AlarmApiTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.security.test.context.support.TestExecutionEvent.TEST_EXECUTION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -59,5 +60,19 @@ class AlarmApiTest {
         // when
         mvc.perform(get("/api/v1/notis/subscribe")).andExpect(status().isOk());
         // then
+    }
+
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TEST_EXECUTION)
+    @DisplayName("알람 읽음 처리 요청")
+    @Test
+    void given_alarmIdAndLoginUser_when_loginUserIsOwnerOfAlarm_then_readAlarm() throws Exception {
+        //given
+        Long alarmId = 1L;
+        given(alarmService.isOwnerOfAlarm(anyLong(), anyLong())).willReturn(true);
+        willDoNothing().given(alarmService).readAlarm(anyLong());
+        //when
+        mvc.perform(get("/api/v1/notis/" + alarmId))
+                .andExpect(status().isOk());
+        //then
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
@@ -2,12 +2,14 @@ package freshtrash.freshtrashbackend.service;
 
 import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
+import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.repository.AlarmRepository;
 import freshtrash.freshtrashbackend.repository.EmitterRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,9 +20,12 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AlarmServiceTest {
@@ -45,6 +50,18 @@ class AlarmServiceTest {
         // when
         Page<AlarmResponse> alarms = alarmService.getAlarms(memberId, pageable);
         // then
-        Assertions.assertThat(alarms.getSize()).isEqualTo(expectedSize);
+        assertThat(alarms.getSize()).isEqualTo(expectedSize);
+    }
+
+    @DisplayName("알람 읽음 처리")
+    @Test
+    void given_alarmId_when_readAlarm_then_updateReadAtToNow() {
+        // given
+        Long alarmId = 1L;
+        willDoNothing().given(alarmRepository).updateReadAtById(anyLong());
+        // when
+        alarmService.readAlarm(alarmId);
+        // then
+        then(alarmRepository).should(times(1)).updateReadAtById(anyLong());
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 프론트에서 알람을 클릭하면 해당 알람에 해당하는 대상 폐기물, 경매 등의 페이지로 이동하고 서버에서는 읽음 처리를 하도록 API를 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 알람 읽음 처리 요청 API 구현
    - 알람 읽음 처리 요청 시 로그인한 사용자가 대상 알람의 주인인지 확인합니다
    - 대상 알람의 주인이 맞다면 알람의 readAt 속성 값을 읽은 일시로 update 합니다
- 알람 update readAt 쿼리 메소드
    - 알람의 읽음 처리를 요청하는 사용자는 해당 알람의 주인 한 명 뿐이기 때문에 Transaction을 적용할 필요가 없다고 판단했습니다.
    - Transaction이 필요없다고 판단하여 native query를 적용했습니다.
- 단위 테스트 코드 작성
- API 테스트
  ![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/fe48b73a-8ad7-4f71-b565-f75d2b2d7a6b)


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #71 
