### PR TITLE
채팅방 목록, 단일 조회 API 구현

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/ChatApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ChatApi.java
@@ -1,0 +1,47 @@
+package freshtrash.freshtrashbackend.controller;
+
+import freshtrash.freshtrashbackend.dto.response.ChatRoomResponse;
+import freshtrash.freshtrashbackend.dto.response.ChatRoomWithMessagesResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.exception.ChatException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/wastes/{wasteId}/chats")
+@RequiredArgsConstructor
+public class ChatApi {
+    private final ChatService chatService;
+
+    @GetMapping
+    public ResponseEntity<Page<ChatRoomResponse>> getChatRooms(
+            @PageableDefault Pageable pageable, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        return ResponseEntity.ok(chatService.getChatRooms(memberPrincipal.id(), pageable));
+    }
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ChatRoomWithMessagesResponse> getChatRoomWithMessages(
+            @PathVariable Long chatRoomId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+
+        checkIfSellerOrBuyerOfChatRoom(chatRoomId, memberPrincipal.id());
+        return ResponseEntity.ok(ChatRoomWithMessagesResponse.fromEntity(chatService.getChatRoom(chatRoomId)));
+    }
+
+    /**
+     * 판매자 또는 구매자만이 대상 채팅방을 조회할 수 있습니다
+     */
+    private void checkIfSellerOrBuyerOfChatRoom(Long chatRoomId, Long memberId) {
+        if (!chatService.isSellerOrBuyerOfChatRoom(chatRoomId, memberId))
+            throw new ChatException(ErrorCode.FORBIDDEN_CHAT_ROOM);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/ChatMessageResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/ChatMessageResponse.java
@@ -1,0 +1,11 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+import freshtrash.freshtrashbackend.entity.ChatMessage;
+
+import java.time.LocalDateTime;
+
+public record ChatMessageResponse(String message, LocalDateTime createdAt) {
+    public static ChatMessageResponse fromEntity(ChatMessage chatMessage) {
+        return new ChatMessageResponse(chatMessage.getMessage(), chatMessage.getCreatedAt());
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/ChatRoomResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/ChatRoomResponse.java
@@ -1,0 +1,23 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+import freshtrash.freshtrashbackend.entity.ChatRoom;
+import freshtrash.freshtrashbackend.entity.constants.SellStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ChatRoomResponse(
+        Long id, SellStatus sellStatus, boolean openOrClose, LocalDateTime createdAt, String sellerNickname, String buyerNickname) {
+
+    public static ChatRoomResponse fromEntity(ChatRoom chatRoom) {
+        return ChatRoomResponse.builder()
+                .id(chatRoom.getId())
+                .sellStatus(chatRoom.getSellStatus())
+                .openOrClose(chatRoom.isOpenOrClose())
+                .createdAt(chatRoom.getCreatedAt())
+                .sellerNickname(chatRoom.getSeller().getNickname())
+                .buyerNickname(chatRoom.getBuyer().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/ChatRoomWithMessagesResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/ChatRoomWithMessagesResponse.java
@@ -1,0 +1,16 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+import freshtrash.freshtrashbackend.entity.ChatRoom;
+
+import java.util.List;
+
+public record ChatRoomWithMessagesResponse(ChatRoomResponse chatRoom, List<ChatMessageResponse> messages) {
+
+    public static ChatRoomWithMessagesResponse fromEntity(ChatRoom chatRoom) {
+        return new ChatRoomWithMessagesResponse(
+                ChatRoomResponse.fromEntity(chatRoom),
+                chatRoom.getChatMessages().stream()
+                        .map(ChatMessageResponse::fromEntity)
+                        .toList());
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/ChatRoom.java
@@ -8,6 +8,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "chat_rooms")
@@ -57,6 +59,10 @@ public class ChatRoom {
 
     @Column(nullable = false)
     private Long buyerId;
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+    private Set<ChatMessage> chatMessages = new LinkedHashSet<>();
 
     @Builder
     private ChatRoom(Long wasteId, Long sellerId, Long buyerId, SellStatus sellStatus, boolean openOrClose) {

--- a/src/main/java/freshtrash/freshtrashbackend/exception/ChatException.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/ChatException.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.exception;
+
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ChatException extends CustomException {
+    public ChatException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ChatException(ErrorCode errorCode, Exception causeException) {
+        super(errorCode, causeException);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -39,7 +39,11 @@ public enum ErrorCode {
 
     // Alarm
     ALARM_CONNECT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알람을 위한 연결 시도 실패"),
-    FORBIDDEN_ALARM(HttpStatus.FORBIDDEN, "알람에 대한 권한이 없습니다.");
+    FORBIDDEN_ALARM(HttpStatus.FORBIDDEN, "알람에 대한 권한이 없습니다."),
+
+    // Chat
+    NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
+    FORBIDDEN_CHAT_ROOM(HttpStatus.FORBIDDEN, "채팅방에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -10,15 +10,20 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Transactional(propagation = Propagation.SUPPORTS)
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findByWaste_Id(Long wasteId);
 
+    @EntityGraph(attributePaths = {"buyer", "seller", "chatMessages"})
+    Optional<ChatRoom> findById(Long chatRoomId);
+
     @EntityGraph(attributePaths = {"buyer", "seller"})
+    @Query("select cr from ChatRoom cr where cr.buyerId = ?1 or cr.sellerId = ?1")
     Page<ChatRoom> findAllBySeller_IdOrBuyer_Id(Long memberId, Pageable pageable);
 
-    @Query("select cr from ChatRoom cr where cr.id = ?1 and (cr.buyerId = ?2 or cr.sellerId = ?2)")
-    boolean existsByIdAndSeller_IdOrBuyer_Id(Long chatRoomId, Long memberId);
+    @Query("select (cr is not null) from ChatRoom cr where cr.id = ?1 and (cr.buyerId = ?2 or cr.sellerId = ?2)")
+    boolean existsByIdAndMemberId(Long chatRoomId, Long memberId);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -1,11 +1,24 @@
 package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Transactional(propagation = Propagation.SUPPORTS)
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findByWaste_Id(Long wasteId);
+
+    @EntityGraph(attributePaths = {"buyer", "seller"})
+    Page<ChatRoom> findAllBySeller_IdOrBuyer_Id(Long memberId, Pageable pageable);
+
+    @Query("select cr from ChatRoom cr where cr.id = ?1 and (cr.buyerId = ?2 or cr.sellerId = ?2)")
+    boolean existsByIdAndSeller_IdOrBuyer_Id(Long chatRoomId, Long memberId);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
@@ -2,10 +2,14 @@ package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Transactional(propagation = Propagation.SUPPORTS)
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findById(Long memberId);
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);

--- a/src/main/java/freshtrash/freshtrashbackend/service/ChatService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ChatService.java
@@ -1,8 +1,13 @@
 package freshtrash.freshtrashbackend.service;
 
+import freshtrash.freshtrashbackend.dto.response.ChatRoomResponse;
 import freshtrash.freshtrashbackend.entity.ChatRoom;
+import freshtrash.freshtrashbackend.exception.ChatException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,5 +19,21 @@ public class ChatService {
 
     public List<ChatRoom> getChatRoomsByWasteId(Long wasteId) {
         return chatRoomRepository.findByWaste_Id(wasteId);
+    }
+
+    public Page<ChatRoomResponse> getChatRooms(Long memberId, Pageable pageable) {
+        return chatRoomRepository
+                .findAllBySeller_IdOrBuyer_Id(memberId, pageable)
+                .map(ChatRoomResponse::fromEntity);
+    }
+
+    public ChatRoom getChatRoom(Long chatRoomId) {
+        return chatRoomRepository
+                .findById(chatRoomId)
+                .orElseThrow(() -> new ChatException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+    }
+
+    public boolean isSellerOrBuyerOfChatRoom(Long chatRoomId, Long memberId) {
+        return chatRoomRepository.existsByIdAndSeller_IdOrBuyer_Id(chatRoomId, memberId);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/ChatService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ChatService.java
@@ -34,6 +34,6 @@ public class ChatService {
     }
 
     public boolean isSellerOrBuyerOfChatRoom(Long chatRoomId, Long memberId) {
-        return chatRoomRepository.existsByIdAndSeller_IdOrBuyer_Id(chatRoomId, memberId);
+        return chatRoomRepository.existsByIdAndMemberId(chatRoomId, memberId);
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -6,6 +6,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 public class Fixture {
     public static Waste createWaste() {
@@ -79,21 +80,35 @@ public class Fixture {
                 .build();
     }
 
-    public static ChatRoom createChatRoom() {
-        return ChatRoom.builder()
-                .buyerId(1L)
-                .sellerId(2L)
-                .wasteId(1L)
-                .openOrClose(true)
-                .sellStatus(SellStatus.ONGOING)
-                .build();
-    }
-
     public static Alarm createAlarm() {
         return Alarm.builder()
                 .memberId(1L)
                 .alarmArgs(AlarmArgs.of(3L, 2L))
                 .alarmType(AlarmType.TRANSACTION)
                 .build();
+    }
+
+    public static ChatRoom createChatRoom() {
+        ChatRoom chatRoom = ChatRoom.builder()
+                .sellStatus(SellStatus.ONGOING)
+                .openOrClose(true)
+                .wasteId(1L)
+                .buyerId(2L)
+                .sellerId(3L)
+                .build();
+        ReflectionTestUtils.setField(
+                chatRoom,
+                "seller",
+                createMember("seller@gmail.com", "pw", "seller", LoginType.EMAIL, UserRole.USER, AccountStatus.ACTIVE));
+        ReflectionTestUtils.setField(
+                chatRoom,
+                "buyer",
+                createMember("buyer@gmail.com", "pw", "buyer", LoginType.EMAIL, UserRole.USER, AccountStatus.ACTIVE));
+        ReflectionTestUtils.setField(chatRoom, "chatMessages", Set.of(createChatMessage()));
+        return chatRoom;
+    }
+
+    public static ChatMessage createChatMessage() {
+        return ChatMessage.of(1L, 2L, "message");
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ChatApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ChatApiTest.java
@@ -1,0 +1,72 @@
+package freshtrash.freshtrashbackend.controller;
+
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.config.TestSecurityConfig;
+import freshtrash.freshtrashbackend.dto.response.ChatRoomResponse;
+import freshtrash.freshtrashbackend.entity.ChatRoom;
+import freshtrash.freshtrashbackend.service.ChatService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestSecurityConfig.class)
+@WebMvcTest(ChatApi.class)
+class ChatApiTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private ChatService chatService;
+
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("채팅방 목록 조회")
+    @Test
+    void given_memberIdAndPageable_when_getChatRooms_then_returnPagingChatRoomsResponse() throws Exception {
+        // given
+        Long wasteId = 1L;
+        int expectedSize = 1;
+        given(chatService.getChatRooms(anyLong(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(ChatRoomResponse.fromEntity(Fixture.createChatRoom()))));
+        // when
+        mvc.perform(get("/api/v1/wastes/" + wasteId + "/chats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size").value(expectedSize));
+        // then
+    }
+
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("채팅방 + 채팅 메시지 조회")
+    @Test
+    void given_chatRoomIdAndMemberId_when_ifSellerOrBuyerOfChatRoom_then_getChatRoomWithMessages() throws Exception {
+        // given
+        Long wasteId = 1L;
+        Long chatRoomId = 2L;
+        ChatRoom chatRoom = Fixture.createChatRoom();
+        given(chatService.isSellerOrBuyerOfChatRoom(anyLong(), anyLong())).willReturn(true);
+        given(chatService.getChatRoom(anyLong())).willReturn(chatRoom);
+        // when
+        mvc.perform(get("/api/v1/wastes/" + wasteId + "/chats/" + chatRoomId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chatRoom.sellerNickname").value(chatRoom.getSeller().getNickname()))
+                .andExpect(jsonPath("$.chatRoom.buyerNickname").value(chatRoom.getBuyer().getNickname()))
+                .andExpect(jsonPath("$.messages.size()").value(chatRoom.getChatMessages().size()));
+        // then
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/service/ChatServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/ChatServiceTest.java
@@ -1,6 +1,7 @@
 package freshtrash.freshtrashbackend.service;
 
 import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.dto.response.ChatRoomResponse;
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.repository.ChatRoomRepository;
 import org.assertj.core.api.Assertions;
@@ -10,9 +11,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
@@ -35,5 +43,32 @@ class ChatServiceTest {
         List<ChatRoom> chatRooms = chatService.getChatRoomsByWasteId(wasteId);
         // then
         Assertions.assertThat(chatRooms.size()).isEqualTo(expectedSize);
+    }
+
+    @DisplayName("채팅방 목록 조회")
+    @Test
+    void given_memberIdAndPageable_when_getChatRooms_then_returnPagingChatRoomsResponse() {
+        // given
+        Long memberId = 1L;
+        int expectedSize = 1;
+        Pageable pageable = PageRequest.of(0, 10);
+        given(chatRoomRepository.findAllBySeller_IdOrBuyer_Id(anyLong(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(Fixture.createChatRoom())));
+        // when
+        Page<ChatRoomResponse> chatRooms = chatService.getChatRooms(memberId, pageable);
+        // then
+        assertThat(chatRooms.getSize()).isEqualTo(expectedSize);
+    }
+
+    @DisplayName("채팅방 단일 조회")
+    @Test
+    void given_chatRoomId_when_getChatRoom_then_returnChatRoom() {
+        // given
+        Long chatRoomId = 1L;
+        given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(Fixture.createChatRoom()));
+        // when
+        ChatRoom chatRoom = chatService.getChatRoom(chatRoomId);
+        // then
+        assertThat(chatRoom).isNotNull();
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 채팅방 목록과 채팅방 단일 + 메시지를 조회하는 API를 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- ChatRoom과 ChatMessage의 oneToMany 연관관계 설정
- 채팅방 조회 API 구현
    - 로그인 사용자의 모든 채팅방을 조회
    - 채팅방 단일 + 모든 메시지 조회
        - 요청 시 조회하려는 채팅방에 대한 권한이 있는지 판단
- 채팅방 조회 단위 테스트 코드 작성
- API 테스트
  - 채팅방 목록
    ![Pasted Graphic](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/1aaf105f-cdbe-4cd7-8b71-3d1bb81cf77f)
  - 채팅방 단일 + 모든 메시지
    ![Pasted Graphic 1](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/c1c8b00f-d146-4dda-96da-67f99304cb80)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- chat_rooms의 open_or_close 속성 타입 수정
  - tinyint -> bit로 수정

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #77 
