### PR TITLE
Waste Update 로직 수정 및 불필요한 Transaction 삭제/리팩토링

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
@@ -81,8 +81,7 @@ public class WasteApi {
         checkIfWriterOrAdmin(memberPrincipal, wasteId);
 
         String savedFileName = wasteService.findFileNameOfWaste(wasteId).fileName();
-        WasteResponse wasteResponse =
-                wasteService.updateWaste(wasteId, imgFile, wasteRequest, memberPrincipal);
+        WasteResponse wasteResponse = wasteService.updateWaste(wasteId, imgFile, wasteRequest, memberPrincipal);
         fileService.deleteFileIfExists(savedFileName);
 
         return ResponseEntity.ok(wasteResponse);
@@ -95,8 +94,8 @@ public class WasteApi {
     public ResponseEntity<Void> deleteWaste(
             @PathVariable Long wasteId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         checkIfWriterOrAdmin(memberPrincipal, wasteId);
-        wasteService.deleteWaste(
-                wasteId, wasteService.findFileNameOfWaste(wasteId).fileName());
+        wasteService.deleteWaste(wasteId);
+        fileService.deleteFileIfExists(wasteService.findFileNameOfWaste(wasteId).fileName());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/WasteApi.java
@@ -1,17 +1,18 @@
 package freshtrash.freshtrashbackend.controller;
 
 import com.querydsl.core.types.Predicate;
-import freshtrash.freshtrashbackend.dto.response.WasteResponse;
 import freshtrash.freshtrashbackend.dto.WasteReviewDto;
+import freshtrash.freshtrashbackend.dto.constants.LikeStatus;
 import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
 import freshtrash.freshtrashbackend.dto.response.ApiResponse;
+import freshtrash.freshtrashbackend.dto.response.WasteResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
-import freshtrash.freshtrashbackend.dto.constants.LikeStatus;
 import freshtrash.freshtrashbackend.entity.Waste;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.exception.WasteException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.service.FileService;
 import freshtrash.freshtrashbackend.service.WasteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -33,6 +34,7 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 @RequiredArgsConstructor
 public class WasteApi {
     private final WasteService wasteService;
+    private final FileService fileService;
 
     /**
      * 폐기물 단일 조회
@@ -75,9 +77,14 @@ public class WasteApi {
             @RequestPart @Valid WasteRequest wasteRequest,
             @PathVariable Long wasteId,
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+
         checkIfWriterOrAdmin(memberPrincipal, wasteId);
-        WasteResponse wasteResponse = wasteService.updateWaste(
-                wasteId, imgFile, wasteRequest, wasteService.findFileNameOfWaste(wasteId).fileName(), memberPrincipal);
+
+        String savedFileName = wasteService.findFileNameOfWaste(wasteId).fileName();
+        WasteResponse wasteResponse =
+                wasteService.updateWaste(wasteId, imgFile, wasteRequest, memberPrincipal);
+        fileService.deleteFileIfExists(savedFileName);
+
         return ResponseEntity.ok(wasteResponse);
     }
 
@@ -88,7 +95,8 @@ public class WasteApi {
     public ResponseEntity<Void> deleteWaste(
             @PathVariable Long wasteId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         checkIfWriterOrAdmin(memberPrincipal, wasteId);
-        wasteService.deleteWaste(wasteId, wasteService.findFileNameOfWaste(wasteId).fileName());
+        wasteService.deleteWaste(
+                wasteId, wasteService.findFileNameOfWaste(wasteId).fileName());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -61,7 +61,6 @@ public class WasteService {
             Long wasteId,
             MultipartFile imgFile,
             WasteRequest wasteRequest,
-            String savedFileName,
             MemberPrincipal memberPrincipal) {
 
         if (!FileUtils.isValid(imgFile)) {
@@ -75,9 +74,6 @@ public class WasteService {
         wasteRepository.save(updatedWaste);
         // 수정된 파일 저장
         fileService.uploadFile(imgFile, updatedFileName);
-        wasteRepository.flush();
-        // 저장된 파일 삭제
-        fileService.deleteFileIfExists(savedFileName);
 
         return WasteResponse.fromEntity(updatedWaste, memberPrincipal);
     }

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteService.java
@@ -58,10 +58,7 @@ public class WasteService {
 
     @Transactional
     public WasteResponse updateWaste(
-            Long wasteId,
-            MultipartFile imgFile,
-            WasteRequest wasteRequest,
-            MemberPrincipal memberPrincipal) {
+            Long wasteId, MultipartFile imgFile, WasteRequest wasteRequest, MemberPrincipal memberPrincipal) {
 
         if (!FileUtils.isValid(imgFile)) {
             throw new FileException(ErrorCode.INVALID_FIlE);
@@ -78,11 +75,8 @@ public class WasteService {
         return WasteResponse.fromEntity(updatedWaste, memberPrincipal);
     }
 
-    @Transactional
-    public void deleteWaste(Long wasteId, String savedFileName) {
+    public void deleteWaste(Long wasteId) {
         wasteRepository.deleteById(wasteId);
-        // 파일 삭제
-        fileService.deleteFileIfExists(savedFileName);
     }
 
     public FileNameSummary findFileNameOfWaste(Long wasteId) {

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -44,23 +44,6 @@ public class FixtureDto {
                 Fixture.createAddress());
     }
 
-    public static WasteResponse createWasteDto() {
-        return new WasteResponse(
-                "title",
-                "content",
-                SellType.SHARE,
-                1000,
-                2,
-                3,
-                "test.png",
-                WasteCategory.BEAUTY,
-                WasteStatus.BEST,
-                SellStatus.CLOSE,
-                Fixture.createAddress(),
-                LocalDateTime.now(),
-                new UserInfo("test", 4, "test.png", Fixture.createAddress()));
-    }
-
     public static MemberPrincipal createMemberPrincipal() {
         return MemberPrincipal.builder()
                 .id(1L)

--- a/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
@@ -14,6 +14,7 @@ import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.entity.constants.WasteCategory;
 import freshtrash.freshtrashbackend.entity.constants.WasteStatus;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
+import freshtrash.freshtrashbackend.service.LocalFileService;
 import freshtrash.freshtrashbackend.service.WasteService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,9 @@ class WasteApiTest {
 
     @MockBean
     private WasteService wasteService;
+
+    @MockBean
+    private LocalFileService localFileService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -193,12 +197,9 @@ class WasteApiTest {
         given(wasteService.isWriterOfArticle(anyLong(), anyLong())).willReturn(true);
         given(wasteService.findFileNameOfWaste(anyLong())).willReturn(new FileNameSummary("test.png"));
         given(wasteService.updateWaste(
-                        anyLong(),
-                        any(MultipartFile.class),
-                        any(WasteRequest.class),
-                        anyString(),
-                        any(MemberPrincipal.class)))
+                        anyLong(), any(MultipartFile.class), any(WasteRequest.class), any(MemberPrincipal.class)))
                 .willReturn(wasteResponse);
+        willDoNothing().given(localFileService).deleteFileIfExists(anyString());
         // when
         mvc.perform(multipart(HttpMethod.PUT, "/api/v1/wastes/" + wasteId)
                         .file("imgFile", imgFile.getBytes())
@@ -227,7 +228,8 @@ class WasteApiTest {
         Long wasteId = 1L;
         given(wasteService.isWriterOfArticle(anyLong(), anyLong())).willReturn(true);
         given(wasteService.findFileNameOfWaste(anyLong())).willReturn(new FileNameSummary("test.png"));
-        willDoNothing().given(wasteService).deleteWaste(anyLong(), anyString());
+        willDoNothing().given(localFileService).deleteFileIfExists(anyString());
+        willDoNothing().given(wasteService).deleteWaste(anyLong());
         // when
         mvc.perform(delete("/api/v1/wastes/" + wasteId)).andExpect(status().isNoContent());
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/service/WasteServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/WasteServiceTest.java
@@ -3,8 +3,8 @@ package freshtrash.freshtrashbackend.service;
 import com.querydsl.core.types.Predicate;
 import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.Fixture.FixtureDto;
-import freshtrash.freshtrashbackend.dto.response.WasteResponse;
 import freshtrash.freshtrashbackend.dto.request.WasteRequest;
+import freshtrash.freshtrashbackend.dto.response.WasteResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.QWaste;
 import freshtrash.freshtrashbackend.entity.Waste;
@@ -78,7 +78,8 @@ class WasteServiceTest {
         given(wasteRepository.save(any(Waste.class))).willReturn(waste);
         willDoNothing().given(fileService).uploadFile(any(MultipartFile.class), anyString());
         // when
-        WasteResponse wasteResponse = wasteService.addWaste(Fixture.createMultipartFile("image"), wasteRequest, memberPrincipal);
+        WasteResponse wasteResponse =
+                wasteService.addWaste(Fixture.createMultipartFile("image"), wasteRequest, memberPrincipal);
         // then
         assertThat(wasteResponse.title()).isEqualTo(wasteRequest.title());
         assertThat(wasteResponse.content()).isEqualTo(wasteRequest.content());
@@ -97,12 +98,13 @@ class WasteServiceTest {
         MockMultipartFile multipartFile = Fixture.createMultipartFile("test content");
         WasteRequest wasteRequest = FixtureDto.createWasteRequest();
         String savedFileName = "saved.png";
+        String updatedFileName = "updated.png";
         MemberPrincipal memberPrincipal = FixtureDto.createMemberPrincipal();
+        Waste waste = Waste.fromRequest(wasteRequest, updatedFileName, memberPrincipal.id());
+        given(wasteRepository.save(any(Waste.class))).willReturn(waste);
         willDoNothing().given(fileService).uploadFile(any(MultipartFile.class), anyString());
-        willDoNothing().given(wasteRepository).flush();
-        willDoNothing().given(fileService).deleteFileIfExists(anyString());
         // when
-        WasteResponse wasteResponse = wasteService.updateWaste(wasteId, multipartFile, wasteRequest, savedFileName, memberPrincipal);
+        WasteResponse wasteResponse = wasteService.updateWaste(wasteId, multipartFile, wasteRequest, memberPrincipal);
         // then
         assertThat(wasteResponse.title()).isEqualTo(wasteRequest.title());
         assertThat(wasteResponse.content()).isEqualTo(wasteRequest.content());
@@ -119,11 +121,9 @@ class WasteServiceTest {
     void given_wasteId_when_then_deleteWasteAndFile() {
         // given
         Long wasteId = 1L;
-        String savedFileName = "saved.png";
         willDoNothing().given(wasteRepository).deleteById(anyLong());
-        willDoNothing().given(fileService).deleteFileIfExists(anyString());
         // when
-        wasteService.deleteWaste(wasteId, savedFileName);
+        wasteService.deleteWaste(wasteId);
         // then
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- Waste 수정 시 save -> upload 후 flush를 해도 파일 delete를 해도 Transaction에 의해 rollback되는 문제가 있습니다. 따라서 수정된 waste의 fileName이 변경되었는지를 판단하여 업로드 여부를 확인하고 이후 파일을 삭제하도록 수정합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- Waste Update 로직에서 파일 삭제 코드를 분리
    - Controller Layer에서 파일 수정 후 분리한 파일 삭제를 실행하도록 수정
- Waste Delete 시 파일 삭제 코드 분리
    - DB 삭제와 파일 삭제는 반드시 같이 실행될 필요없으므로 Transaction을 삭제하고 파일 삭제 코드를 분리
- 테스트 코드 수정

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #87 
