### PR TITLE
Redis를 사용한 유저 정보 캐싱

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/config/RedisConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/RedisConfig.java
@@ -2,19 +2,16 @@ package freshtrash.freshtrashbackend.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
-import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @Configuration
+@EnableRedisRepositories
 @RequiredArgsConstructor
 public class RedisConfig {
     private final RedisProperties redisProperties;
@@ -23,12 +20,5 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(
                 new RedisStandaloneConfiguration(redisProperties.getHost(), redisProperties.getPort()));
-    }
-
-    @Bean
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
-        return redisTemplate;
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/cache/EmailCodeCache.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/cache/EmailCodeCache.java
@@ -2,11 +2,10 @@ package freshtrash.freshtrashbackend.dto.cache;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.TimeToLive;
 
-@RedisHash(value = "emailCode")
-public record EmailCodeCache(@Id String email, String code, @TimeToLive Long expiration) {
-    public static EmailCodeCache of(String email, String code, Long expiration) {
-        return new EmailCodeCache(email, code, expiration);
+@RedisHash(value = "EmailCode", timeToLive = 10 * 60)
+public record EmailCodeCache(@Id String email, String code) {
+    public static EmailCodeCache of(String email, String code) {
+        return new EmailCodeCache(email, code);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
@@ -1,10 +1,13 @@
 package freshtrash.freshtrashbackend.dto.security;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import freshtrash.freshtrashbackend.entity.Address;
 import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.security.TokenInfo;
 import lombok.Builder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,16 +18,17 @@ import java.util.Map;
 import java.util.Set;
 
 @Builder
+@RedisHash(value = "Member")
 public record MemberPrincipal(
-        Long id,
+        @Id Long id,
         String email,
         String password,
-        Collection<? extends GrantedAuthority> authorities,
+        @JsonIgnore Collection<? extends GrantedAuthority> authorities,
         String nickname,
         double rating,
         String fileName,
         Address address,
-        Map<String, Object> oAuth2Attributes)
+        @JsonIgnore Map<String, Object> oAuth2Attributes)
         implements UserDetails, OAuth2User {
 
     public static class MemberPrincipalBuilder {

--- a/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/security/MemberPrincipal.java
@@ -22,7 +22,7 @@ import java.util.Set;
 public record MemberPrincipal(
         @Id Long id,
         String email,
-        String password,
+        @JsonIgnore String password,
         @JsonIgnore Collection<? extends GrantedAuthority> authorities,
         String nickname,
         double rating,

--- a/src/main/java/freshtrash/freshtrashbackend/repository/MemberCacheRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/MemberCacheRepository.java
@@ -1,0 +1,6 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import org.springframework.data.repository.CrudRepository;
+
+public interface MemberCacheRepository extends CrudRepository<MemberPrincipal, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/security/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/CustomOAuth2SuccessHandler.java
@@ -23,13 +23,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException {
         MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
-        String accessToken = tokenProvider.generateAccessToken(
-                principal.email(),
-                principal.nickname(),
-                String.format("%s:%s", principal.id(), principal.getUserRole().getName()),
-                principal.rating(),
-                principal.fileName(),
-                principal.address());
+        String accessToken = tokenProvider.generateAccessToken(principal.id());
         response.getOutputStream().println(mapper.writeValueAsString(LoginResponse.of(accessToken)));
         // TODO: 회원가입되지 않은 계정일 경우 처리
     }

--- a/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
 
             // 회원이 존재하지 않는다면 저장하지 않고 회원가입이 안된 상태로 반환
             try {
-                return MemberPrincipal.fromEntity(memberService.getMemberEntityByEmail(email));
+                return MemberPrincipal.fromEntity(memberService.getMemberByEmail(email));
             } catch (MemberException e) {
                 return MemberPrincipal.builder()
                         .email(email)
@@ -86,7 +86,7 @@ public class SecurityConfig {
 
     @Bean
     public UserDetailsService userDetailsService(MemberService memberService) {
-        return email -> MemberPrincipal.fromEntity(memberService.getMemberEntityByEmail(email));
+        return email -> MemberPrincipal.fromEntity(memberService.getMemberByEmail(email));
     }
 
     @Bean

--- a/src/main/java/freshtrash/freshtrashbackend/security/TokenProvider.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/TokenProvider.java
@@ -1,11 +1,7 @@
 package freshtrash.freshtrashbackend.security;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import freshtrash.freshtrashbackend.dto.properties.JwtProperties;
-import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
-import freshtrash.freshtrashbackend.entity.Address;
-import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.exception.AuthException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -20,51 +16,38 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenProvider {
-    private static final String KEY_EMAIL = "email";
-    private static final String KEY_NICKNAME = "nickname";
-    private static final String KEY_SPEC = "spec";
-    private static final String SPEC_SEPARATOR = ":";
-    private static final String KEY_RATING = "rating";
-    private static final String KEY_FILENAME = "fileName";
-    private static final String KEY_ADDRESS = "address";
+    private static final String KEY_ID = "id";
     private final ObjectMapper mapper;
     private final JwtProperties jwtProperties;
 
     /**
      * 토큰 발급
      */
-    public String generateAccessToken(
-            String email, String nickname, String spec, double rating, String fileName, Address address) {
-        try {
-            Map<String, String> claims = new HashMap<>();
-            claims.put(KEY_EMAIL, email);
-            claims.put(KEY_NICKNAME, nickname);
-            claims.put(KEY_SPEC, spec); // "id:role"
-            claims.put(KEY_RATING, String.valueOf(rating));
-            claims.put(KEY_FILENAME, fileName);
-            claims.put(KEY_ADDRESS, mapper.writeValueAsString(address));
+    public String generateAccessToken(Long memberId) {
+        Map<String, Long> claims = new HashMap<>();
+        claims.put(KEY_ID, memberId);
 
-            return Jwts.builder()
-                    .claims(claims)
-                    .issuedAt(new Date(System.currentTimeMillis()))
-                    .expiration(new Date(System.currentTimeMillis() + jwtProperties.accessExpiredMs()))
-                    .signWith(getKey(jwtProperties.secretKey()))
-                    .compact();
-        } catch (JsonProcessingException e) {
-            throw new AuthException("Failed generate token", e);
-        }
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.accessExpiredMs()))
+                .signWith(getKey(jwtProperties.secretKey()))
+                .compact();
+    }
+
+    public Long getMemberIdFromToken(String token) {
+        return parseOrValidateClaims(token).get(KEY_ID, Long.class);
     }
 
     /**
      * 토큰 파싱
      */
-    public Claims parseOrValidateClaims(String token) {
+    private Claims parseOrValidateClaims(String token) {
         try {
             return Jwts.parser()
                     .verifyWith(getKey(jwtProperties.secretKey()))
@@ -74,33 +57,6 @@ public class TokenProvider {
         } catch (ExpiredJwtException e) {
             throw new AuthException("Expired token", e);
         }
-    }
-
-    public TokenInfo parseSpecification(Claims claims) {
-        try {
-            String[] sepcs = claims.get(TokenProvider.KEY_SPEC, String.class).split(SPEC_SEPARATOR);
-            return TokenInfo.builder()
-                    .id(Long.parseLong(sepcs[0]))
-                    .email(claims.get(TokenProvider.KEY_EMAIL, String.class))
-                    .nickname(claims.get(TokenProvider.KEY_NICKNAME, String.class))
-                    .userRole(UserRole.valueOf(sepcs[1].substring(5)))
-                    .rating(Double.parseDouble(claims.get(TokenProvider.KEY_RATING, String.class)))
-                    .fileName(claims.get(TokenProvider.KEY_FILENAME, String.class))
-                    .address(mapper.readValue(claims.get(TokenProvider.KEY_ADDRESS, String.class), Address.class))
-                    .build();
-        } catch (JsonProcessingException | RuntimeException e) {
-            log.error("failed token parsing");
-            return null;
-        }
-    }
-
-    /**
-     * 토큰에 있는 정보로 UserDetails 생성
-     */
-    public MemberPrincipal getUserDetails(Claims claims) {
-        TokenInfo tokenInfo =
-                Optional.ofNullable(claims).map(this::parseSpecification).orElse(TokenInfo.ofAnonymous());
-        return tokenInfo.toMemberPrincipal();
     }
 
     private SecretKey getKey(String key) {

--- a/src/main/java/freshtrash/freshtrashbackend/service/MailService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MailService.java
@@ -29,13 +29,12 @@ public class MailService {
     private final JavaMailSender mailSender;
     private final MailProperties mailProperties;
     private final EmailCodeCacheRepository emailCodeCacheRepository;
-    private final long AUTH_CODE_EXPIRED_SECONDS = 10 * 60;
 
     @Async
     public void sendMailWithCode(String email, String subject, String code) {
         String text = "fresh-trash 메일 인증 코드입니다. <br/>인증코드:" + code;
         sendMail(email, subject, text);
-        emailCodeCacheRepository.save(EmailCodeCache.of(email, code, AUTH_CODE_EXPIRED_SECONDS));
+        emailCodeCacheRepository.save(EmailCodeCache.of(email, code));
         log.debug("--reids에 code 저장");
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
@@ -13,6 +13,7 @@ import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import freshtrash.freshtrashbackend.security.TokenProvider;
 import freshtrash.freshtrashbackend.utils.FileUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -108,6 +109,7 @@ public class MemberService {
             // 수정된 파일 저장
             fileService.uploadFile(imgFile, updatedFileName);
         }
+        memberCacheRepository.save(MemberPrincipal.fromEntity(member));
 
         return member;
     }

--- a/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
@@ -2,10 +2,12 @@ package freshtrash.freshtrashbackend.service;
 
 import freshtrash.freshtrashbackend.dto.request.MemberRequest;
 import freshtrash.freshtrashbackend.dto.response.LoginResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.exception.AuthException;
 import freshtrash.freshtrashbackend.exception.MemberException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.repository.MemberCacheRepository;
 import freshtrash.freshtrashbackend.repository.MemberRepository;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import freshtrash.freshtrashbackend.security.TokenProvider;
@@ -21,12 +23,23 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final MemberCacheRepository memberCacheRepository;
     private final PasswordEncoder encoder;
     private final TokenProvider tokenProvider;
     private final FileService fileService;
 
-    public Member getMemberEntityByEmail(String email) {
+    public Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    public MemberPrincipal getMemberCache(Long memberId) {
+        return memberCacheRepository
+                .findById(memberId)
+                .orElseGet(() -> MemberPrincipal.fromEntity(getMemberById(memberId)));
     }
 
     /**
@@ -43,10 +56,11 @@ public class MemberService {
      * 로그인
      */
     public LoginResponse signIn(String email, String password) {
-        Member member = getMemberEntityByEmail(email);
+        Member member = getMemberByEmail(email);
         checkPassword(password, member.getPassword());
         // 토큰 발급
-        String accessToken = generateAccessToken(email, member);
+        String accessToken = tokenProvider.generateAccessToken(member.getId());
+        memberCacheRepository.save(MemberPrincipal.fromEntity(member));
         return LoginResponse.of(accessToken);
     }
 
@@ -66,30 +80,6 @@ public class MemberService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new MemberException(ErrorCode.ALREADY_EXISTS_NICKNAME);
         }
-    }
-
-    /**
-     * 비밀번호 일치 확인
-     * @param inputPassword 입력한 비밀번호
-     * @param existPassword 기존 비밀번호
-     */
-    private void checkPassword(String inputPassword, String existPassword) {
-        if (!encoder.matches(inputPassword, existPassword)) {
-            throw new AuthException("not matched password");
-        }
-    }
-
-    /**
-     * AccessToken 발급
-     */
-    private String generateAccessToken(String email, Member member) {
-        return tokenProvider.generateAccessToken(
-                email,
-                member.getNickname(),
-                String.format("%s:%s", member.getId(), member.getUserRole().getName()),
-                member.getRating(),
-                member.getFileName(),
-                member.getAddress());
     }
 
     /**
@@ -135,5 +125,16 @@ public class MemberService {
         return memberRepository
                 .findFileNameById(memberId)
                 .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    /**
+     * 비밀번호 일치 확인
+     * @param inputPassword 입력한 비밀번호
+     * @param existPassword 기존 비밀번호
+     */
+    private void checkPassword(String inputPassword, String existPassword) {
+        if (!encoder.matches(inputPassword, existPassword)) {
+            throw new AuthException("not matched password");
+        }
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
+++ b/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
@@ -35,7 +35,7 @@ public class TestSecurityConfig {
     @BeforeTestMethod
     void securitySetUp() {
         String userEmail = "testUser@gmail.com";
-        given(memberService.getMemberEntityByEmail(eq(userEmail))).willReturn(createMember(userEmail));
+        given(memberService.getMemberByEmail(eq(userEmail))).willReturn(createMember(userEmail));
     }
 
     private Member createMember(String email) {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 클라이언트에 전달되는 토큰에 유저 정보들이 담겨있습니다. 이때 토큰에 담긴 유저 정보들이 클라이언트에 저장되면 보안적인면에서 취약할 수 있고 토큰에 담긴 정보들이 적지않기 때문에 요청할 때 비용이 발생합니다. 따라서 토큰에는 유저의 Id 정도만 담아두고 유저 정보를 Redis에 캐싱하여 가져와 사용하도록 기능을 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- RedisConfig 수정
    - 사용하지 않는 RedisTemplate 빈 삭제
- 유저 정보 캐싱
    - 로그인 후 member id를 토큰의 payload에 담아 발급하고 redis에 MemberPrincipal을 캐싱
    - API 요청 시 토큰을 받고 토큰에 담긴 id로 캐싱한 유저 정보 조회
- 캐싱 여부 확인
    
    <img width="426" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/e458df07-d18d-40b5-aed8-07d026d2b0ae">


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- EmailCode의 TTL 설정을 `@RedisHash`에 설정

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #83
