### PR TITLE
유저정보 수정에서 기존파일 null 체크 & 회원가입 비밀번호 유효성 체크 

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,7 +43,7 @@ public class MemberApi {
                 MemberResponse.fromEntity(memberService.updateMember(memberPrincipal.id(), memberRequest, imgFile));
 
         // 파일이 수정된 경우 -> 이전 파일 삭제
-        if (!oldFile.equals(memberResponse.fileName())) {
+        if (StringUtils.hasText(oldFile) && !oldFile.equals(memberResponse.fileName())) {
             memberService.deleteOldFile(oldFile);
         }
         return ResponseEntity.ok(memberResponse);

--- a/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
@@ -36,7 +36,7 @@ public class MemberApi {
     public ResponseEntity<MemberResponse> updateMember(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @RequestPart MemberRequest memberRequest,
-            @RequestPart MultipartFile imgFile) {
+            @RequestPart(required = false) MultipartFile imgFile) {
         String oldFile =
                 memberService.findFileNameOfMember(memberPrincipal.id()).fileName();
         MemberResponse memberResponse =

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/SignUpRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/SignUpRequest.java
@@ -2,5 +2,12 @@ package freshtrash.freshtrashbackend.dto.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
-public record SignUpRequest(@NotBlank String nickname, @NotBlank @Email String email, @NotBlank String password) {}
+public record SignUpRequest(
+        @NotBlank String nickname,
+        @NotBlank @Email String email,
+        @Pattern(
+                        regexp = "(?=.*[0-9])(?=.*[a-z])(?=.*\\W)(?=\\S+$).{8,20}",
+                        message = "비밀번호는 영문자와 숫자, 특수기호가 적어도 1개 이상 포함된 8자~20자의 비밀번호여야 합니다.")
+                String password) {}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
- 초기 회원가입된 유저의 경우 프로필 이미지 파일이 null 값을 가지고 있는데, 현재 유저정보수정 기능에서 기존 이미지파일 null체크가 없어서 기존파일 삭제 전 null값 조건을 추가하려 합니다 
- 회원가입시 비밀번호 유효성 추가 

## ✨ 이 PR에서 핵심적으로 변경된 사항
- 유저정보수정에서 이전파일 삭제전 StringUtils.hasText(oldFile) 조건 추가 
- SignUpRequest에 @Pattern 추가 (비밀번호는 영문자와 숫자, 특수기호가 적어도 1개 이상 포함)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음 

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed : #97 
