### PR TITLE
SSE 연결 시도할 때 이전에 생성한 SseEmitter가 존재하는지 확인

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/repository/EmitterRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/EmitterRepository.java
@@ -19,12 +19,12 @@ public class EmitterRepository {
         return sseEmitter;
     }
 
-    public Optional<SseEmitter> get(Long memberId) {
+    public Optional<SseEmitter> findByMemberId(Long memberId) {
         String key = getKey(memberId);
         return Optional.ofNullable(emitterMap.get(key));
     }
 
-    public void delete(Long memberId) {
+    public void deleteByMemberId(Long memberId) {
         emitterMap.remove(getKey(memberId));
     }
 


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- MPA(Multi-Page Application)에서 페이지 이동 시마다 새로운 SseEmitter를 생성합니다. 그리고 이전에 생성한 SseEmitter는 그대로 남게됩니다. 따라서 페이지 이동 시 Sse 연결을 시도할 때 이전에 생성한 SseEmitter가 있는지 확인 후 없을 경우에만 생성하도록 합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- SSE 연결 시도할 때 이전에 생성한 SseEmitter가 존재하는지 확인합니다.
    - 이전에 생성한 SseEmitter가 없을 경우에만 새로 생성합니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #100 
