### PR TITLE
판매자가 판매 중인 폐기물과 판매한 폐기물을 구분하여 조회

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/TransactionMemberType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/TransactionMemberType.java
@@ -1,6 +1,7 @@
 package freshtrash.freshtrashbackend.dto.constants;
 
 public enum TransactionMemberType {
-    SELLER,
+    SELLER_ONGOING,
+    SELLER_CLOSE,
     BUYER
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
@@ -2,12 +2,15 @@ package freshtrash.freshtrashbackend.repository;
 
 import com.querydsl.core.types.dsl.EnumExpression;
 import com.querydsl.core.types.dsl.StringPath;
+import freshtrash.freshtrashbackend.dto.response.WasteResponse;
 import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.entity.QWaste;
 import freshtrash.freshtrashbackend.entity.Waste;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.repository.custom.CustomWasteRepository;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -50,4 +53,7 @@ public interface WasteRepository
 
     @Query(nativeQuery = true, value = "update wastes w set w.view_count = w.view_count + 1 where w.id = ?1")
     void updateViewCount(Long wasteId);
+
+    @EntityGraph(attributePaths = "member")
+    Page<Waste> findAllByMemberIdAndSellStatusNot(Long memberId, SellStatus sellStatus, Pageable pageable);
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 프론트의 요구사항에 따라 판매자가 판매 폐기물을 조회하려고 할 때 Close, Booking, Ongoing인 상태 모두 반환하도록 합니다. 이때 Close인 상태의 폐기물, Close가 아닌 폐기물을 구분해야합니다. 그러면 프론트에서 판매자가 판매 중(Close가 아닌)인 폐기물과 판매 완료(Close)한 폐기물을 구분하여 화면에 표시할 수 있습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- memberType을 SELLER_ONGOING, SELLER_CLOSE로 구분
    - SELLER_ONGOING: 판매 중 폐기물 조회
    - SELLER_CLOSE: 판매 완료 폐기물 조회
- API 테스트
        
    ![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/72f6c856-4807-4666-8e1d-27df4ded0fd3)
    

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #104 104
