### PR TITLE
채팅 pub/sub 구현

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/config/WebSocketConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/WebSocketConfig.java
@@ -13,13 +13,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // 클라이언트가 연결할 웹소켓 엔드포인트 설정
-        registry.addEndpoint("/ws").setAllowedOrigins("*");
+        registry.addEndpoint("/chat-ws").setAllowedOrigins("http://localhost:5173");
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 메시지를 라우팅할 경로의 접두사 설정
-        registry.enableSimpleBroker("/topic");
+        registry.enableSimpleBroker("/chat");
         registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/ChatApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ChatApi.java
@@ -43,14 +43,6 @@ public class ChatApi {
     }
 
     /**
-     * 판매자 또는 구매자만이 대상 채팅방을 조회할 수 있습니다
-     */
-    private void checkIfSellerOrBuyerOfChatRoom(Long chatRoomId, Long memberId) {
-        if (!chatService.isSellerOrBuyerOfChatRoom(chatRoomId, memberId))
-            throw new ChatException(ErrorCode.FORBIDDEN_CHAT_ROOM);
-    }
-
-    /**
      * 채팅 요청
      */
     @PostMapping
@@ -65,6 +57,14 @@ public class ChatApi {
                 ChatRoomResponse.fromEntity(chatRoom, seller.getNickname(), memberPrincipal.nickname());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 판매자 또는 구매자만이 대상 채팅방을 조회할 수 있습니다
+     */
+    private void checkIfSellerOrBuyerOfChatRoom(Long chatRoomId, Long memberId) {
+        if (!chatService.isSellerOrBuyerOfChatRoom(chatRoomId, memberId))
+            throw new ChatException(ErrorCode.FORBIDDEN_CHAT_ROOM);
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/controller/ChatMessageApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ChatMessageApi.java
@@ -1,0 +1,32 @@
+package freshtrash.freshtrashbackend.controller;
+
+import freshtrash.freshtrashbackend.dto.request.ChatMessageRequest;
+import freshtrash.freshtrashbackend.dto.response.ChatMessageResponse;
+import freshtrash.freshtrashbackend.service.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageApi {
+    private final ChatMessageService chatMessageService;
+
+    /**
+     * 채팅 pub/sub
+     * @param chatRoomId 채팅 중인 채팅방 id
+     * @param memberId 메시지를 전송한 유저 id
+     */
+    @MessageMapping("/{chatRoomId}/message/{memberId}")
+    @SendTo("/chat/{chatRoomId}/message")
+    public ChatMessageResponse sendChatMessage(
+            @DestinationVariable Long chatRoomId,
+            @DestinationVariable Long memberId,
+            ChatMessageRequest chatMessageRequest) {
+
+        return ChatMessageResponse.fromEntity(
+                chatMessageService.saveChatMessage(chatRoomId, memberId, chatMessageRequest.message()));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/ChatMessageRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/ChatMessageRequest.java
@@ -1,0 +1,6 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+public record ChatMessageRequest(
+        String message
+) {
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/ChatMessageService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ChatMessageService.java
@@ -1,0 +1,16 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.entity.ChatMessage;
+import freshtrash.freshtrashbackend.repository.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+    private final ChatMessageRepository chatMessageRepository;
+
+    public ChatMessage saveChatMessage(Long chatRoomId, Long memberId, String message) {
+        return chatMessageRepository.save(ChatMessage.of(chatRoomId, memberId, message));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/ChatService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ChatService.java
@@ -18,7 +18,9 @@ import java.util.List;
 public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
 
-    // TODO: 메소드 네이밍 수정
+    /**
+     * wasteId에 해당하며 전달받은 SellStatus가 아닌 채팅방들을 조회
+     */
     public List<ChatRoom> getChatRoomsByWasteId(Long wasteId, SellStatus sellStatus) {
         return chatRoomRepository.findByWaste_IdAndSellStatusNot(wasteId, sellStatus);
     }

--- a/src/main/resources/static/chat_stomp.js
+++ b/src/main/resources/static/chat_stomp.js
@@ -1,0 +1,63 @@
+const stompClient = new StompJs.Client({
+    brokerURL: 'ws://localhost:8080/chat-ws'
+});
+
+stompClient.onConnect = (frame) => {
+    setConnected(true);
+    console.log('Connected: ' + frame);
+    stompClient.subscribe('/chat/1/message', (greeting) => {
+        console.log('subscribe: ' + JSON.stringify(greeting.body));
+        showGreeting(JSON.parse(greeting.body).message);
+        showGreeting(JSON.parse(greeting.body).createdAt);
+    });
+};
+
+stompClient.onWebSocketError = (error) => {
+    console.error('Error with websocket', error);
+};
+
+stompClient.onStompError = (frame) => {
+    console.error('Broker reported error: ' + frame.headers['message']);
+    console.error('Additional details: ' + frame.body);
+};
+
+function setConnected(connected) {
+    $("#connect").prop("disabled", connected);
+    $("#disconnect").prop("disabled", !connected);
+    if (connected) {
+        $("#conversation").show();
+    } else {
+        $("#conversation").hide();
+    }
+    $("#greetings").html("");
+}
+
+function connect() {
+    stompClient.activate();
+}
+
+function disconnect() {
+    stompClient.deactivate();
+    setConnected(false);
+    console.log("Disconnected");
+}
+
+function sendName() {
+    var name = $("#name").val();
+    console.log("publish: " + name);
+    stompClient.publish({
+        destination: "/app/1/message/1",
+        body: JSON.stringify({'message': name})
+    });
+}
+
+function showGreeting(message) {
+    $("#greetings").append("<tr><td>" + message + "</td></tr>");
+}
+
+$(function () {
+    $("form").on('submit', (e) => e.preventDefault());
+    $("#connect").click(() => connect());
+    $("#disconnect").click(() => disconnect());
+    $("#send").click(() => sendName());
+});

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello WebSocket</title>
+    <link crossorigin="anonymous" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" rel="stylesheet">
+    <link href="/main.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
+    <script src="/chat_stomp.js"></script>
+</head>
+<body>
+<noscript><h2 style="color: #ff0000">Seems your browser doesn't support Javascript! Websocket relies on Javascript being
+    enabled. Please enable
+    Javascript and reload this page!</h2></noscript>
+<div class="container" id="main-content">
+    <div class="row">
+        <div class="col-md-6">
+            <form class="form-inline">
+                <div class="form-group">
+                    <label for="connect">WebSocket connection:</label>
+                    <button class="btn btn-default" id="connect" type="submit">Connect</button>
+                    <button class="btn btn-default" disabled="disabled" id="disconnect" type="submit">Disconnect
+                    </button>
+                </div>
+            </form>
+        </div>
+        <div class="col-md-6">
+            <form class="form-inline">
+                <div class="form-group">
+                    <label for="name">What is your name?</label>
+                    <input class="form-control" id="name" placeholder="Your name here..." type="text">
+                </div>
+                <button class="btn btn-default" id="send" type="submit">Send</button>
+            </form>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <table class="table table-striped" id="conversation">
+                <thead>
+                <tr>
+                    <th>Greetings</th>
+                </tr>
+                </thead>
+                <tbody id="greetings">
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
- 채팅방에서 판매자/구매자 간의 메시지 전송을 위해 웹소켓 stomp를 사용한 pub/sub 기능을 구현합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
- websocket config 수정
    - ws -> chat-ws 로 수정
    - subscribe prefix를 topic -> chat으로 수정
    - 웹소켓의 allowedOrigins를 * -> localhost:5173 으로 제한

- chatMessageApi 추가
    - 서버 기준 subscribe: /{chatRoomId}/message/{memberId}
    - 서버 기준 publish: /chat/{chatRoomId}/message
    - DB에 메시지를 저장하고 클라이언트로 publish 합니다.

- 채팅 pub/sub 테스트
    - 임의로 html/js를 추가하여 테스트를 수행했습니다.
       
        <img width="1166" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/72f38287-c39e-483d-8266-2e304c925203">


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #92 
