### PR TITLE
OAuth 인증 완료 후 토큰 전달 및 사용자 정보와 함께 redirect 적용

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/security/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/CustomOAuth2SuccessHandler.java
@@ -1,30 +1,47 @@
 package freshtrash.freshtrashbackend.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import freshtrash.freshtrashbackend.dto.response.LoginResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final TokenProvider tokenProvider;
-    private final ObjectMapper mapper;
+    private static final String REDIRECT_URI = "http://localhost:5173/";
+    private static final String TOKEN_COOKIE_NAME = "accessToken";
+    private static final String OAUTH_INFO_COOKIE_NAME = "oauthInfo";
+    private static final int COOKIE_MAX_AGE = 10 * 60; // 10분
 
     @Override
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException {
         MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
-        String accessToken = tokenProvider.generateAccessToken(principal.id());
-        response.getOutputStream().println(mapper.writeValueAsString(LoginResponse.of(accessToken)));
-        // TODO: 회원가입되지 않은 계정일 경우 처리
+        // 회원가입되지 않았을 경우 회원가입 페이지로 redirect
+        if (Objects.isNull(principal.id())) {
+            addCookie(
+                    response, OAUTH_INFO_COOKIE_NAME, String.format("%s_%s", principal.email(), principal.nickname()));
+            response.sendRedirect(REDIRECT_URI + "SignUpSignIn");
+        } else {
+            String accessToken = tokenProvider.generateAccessToken(principal.id());
+            addCookie(response, TOKEN_COOKIE_NAME, accessToken);
+            response.sendRedirect(REDIRECT_URI);
+        }
+    }
+
+    private void addCookie(HttpServletResponse response, String cookieName, String cookieValue) {
+        Cookie cookie = new Cookie(cookieName, cookieValue);
+        cookie.setMaxAge(COOKIE_MAX_AGE);
+        cookie.setPath("/");
+        response.addCookie(cookie);
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- OAuth 인증 후 토큰을 클라이언트에게 넘겨줄 수 있도록 코드를 수정합니다. 또한 회원가입이 되지않았을 경우 이메일, 닉네임 정보와 함께 회원가입 페이지로 redirect할 수 있도록 적용합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- 적용한 로직
    - 회원가입이 되었을 경우 토큰과 함께 홈페이지로 redirect합니다.
    - 회원가입이 안되었을 경우 사용자 정보와 함께 회원가입 페이지로 redirect 합니다.

- 쿠키 설정
    - 클라이언트에 전달되는 쿠키 설정은 다음과 같습니다.
        - maxAge: 10분
        - path: /

- 추후 실제로 배포하게될 경우 수정될 수 있습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #114 
