### PR TITLE
채팅방에서 판매상태 변경(예약중, 판매중) 기능 

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/TransactionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/TransactionApi.java
@@ -89,7 +89,7 @@ public class TransactionApi {
      * 판매상태 변경(예약중, 판매중) - 판매자가 변경
      */
     @PostMapping("/chats/{chatRoomId}/status")
-    public ResponseEntity<Void> updateBooking(@PathVariable Long chatRoomId, @RequestParam SellStatus sellStatus) {
+    public ResponseEntity<Void> updateSellStatus(@PathVariable Long chatRoomId, @RequestParam SellStatus sellStatus) {
         ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
         transactionService.updateSellStatus(chatRoom.getWasteId(), chatRoomId, sellStatus);
         if (sellStatus == SellStatus.BOOKING) {
@@ -103,7 +103,7 @@ public class TransactionApi {
                     .alarmType(AlarmType.TRANSACTION)
                     .build());
         } else if (sellStatus == SellStatus.ONGOING) {
-            // 해당 폐기물에 채팅요청했던 다른 구매자들에게 판매중 알림 보내기
+            // 해당 폐기물에 채팅요청했던 다른 구매자들에게 판매중 알림 보내기(현재 채팅방 구매자는 제외)
             chatRoomService
                     .getBuyerIdByWasteId(chatRoom.getWasteId(), chatRoom.getBuyerId())
                     .forEach(buyerIdSummary -> {

--- a/src/main/java/freshtrash/freshtrashbackend/controller/TransactionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/TransactionApi.java
@@ -86,23 +86,38 @@ public class TransactionApi {
     }
 
     /**
-     * 예약중으로 변경(판매자)
+     * 판매상태 변경(예약중, 판매중) - 판매자가 변경
      */
-    @PostMapping("/chats/{chatRoomId}/booking")
-    public ResponseEntity<Void> updateBooking(@PathVariable Long chatRoomId) {
+    @PostMapping("/chats/{chatRoomId}/status")
+    public ResponseEntity<Void> updateBooking(@PathVariable Long chatRoomId, @RequestParam SellStatus sellStatus) {
         ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
-        String message =
-                String.format(BOOKING_MESSAGE.getMessage(), chatRoom.getSeller().getNickname());
-
-        transactionService.updateSellStatus(chatRoom.getWasteId(), chatRoomId, SellStatus.BOOKING);
-        // 구매자에게 알림 보내기
-        sendWasteTransactionMessage(MessageRequest.builder()
-                .message(message)
-                .wasteId(chatRoom.getWasteId())
-                .memberId(chatRoom.getBuyerId())
-                .fromMemberId(chatRoom.getSellerId())
-                .alarmType(AlarmType.TRANSACTION)
-                .build());
+        transactionService.updateSellStatus(chatRoom.getWasteId(), chatRoomId, sellStatus);
+        if (sellStatus == SellStatus.BOOKING) {
+            // 구매자에게 예약중 알림 보내기
+            sendWasteTransactionMessage(MessageRequest.builder()
+                    .message(String.format(
+                            BOOKING_MESSAGE.getMessage(), chatRoom.getSeller().getNickname()))
+                    .wasteId(chatRoom.getWasteId())
+                    .memberId(chatRoom.getBuyerId())
+                    .fromMemberId(chatRoom.getSellerId())
+                    .alarmType(AlarmType.TRANSACTION)
+                    .build());
+        } else if (sellStatus == SellStatus.ONGOING) {
+            // 해당 폐기물에 채팅요청했던 다른 구매자들에게 판매중 알림 보내기
+            chatRoomService
+                    .getBuyerIdByWasteId(chatRoom.getWasteId(), chatRoom.getBuyerId())
+                    .forEach(buyerIdSummary -> {
+                        sendWasteTransactionMessage(MessageRequest.builder()
+                                .message(String.format(
+                                        ONGOING_MESSAGE.getMessage(),
+                                        chatRoom.getSeller().getNickname()))
+                                .wasteId(chatRoom.getWasteId())
+                                .memberId(buyerIdSummary.buyerId())
+                                .fromMemberId(chatRoom.getSellerId())
+                                .alarmType(AlarmType.TRANSACTION)
+                                .build());
+                    });
+        }
 
         return ResponseEntity.ok(null);
     }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
@@ -9,6 +9,7 @@ public enum AlarmMessage {
     COMPLETED_SELL_MESSAGE("판매 완료되었습니다."),
     REQUEST_REVIEW_MESSAGE("판매 완료되었습니다. 판매자에 대한 리뷰를 작성해주세요."),
     BOOKING_MESSAGE("%s님이 예약중으로 판매상태를 변경하였습니다."),
+    ONGOING_MESSAGE("%s님이 판매중으로 판매상태를 변경하였습니다."),
     FLAG_MESSAGE("%d번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다."),
     EXCEED_FLAG_MESSAGE("10번이상 신고받으셔서 더이상 서비스를 이용하실 수 없습니다.");
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
+import freshtrash.freshtrashbackend.repository.projections.BuyerIdSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -18,6 +19,8 @@ import java.util.Optional;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findByWaste_IdAndSellStatusNot(Long wasteId, SellStatus sellStatus);
+
+    List<BuyerIdSummary> findBuyer_IdByWaste_IdAndBuyer_IdNot(Long wasteId, Long buyerId);
 
     @EntityGraph(attributePaths = {"waste", "buyer", "seller", "chatMessages"})
     Optional<ChatRoom> findById(Long chatRoomId);

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -20,7 +20,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findByWaste_IdAndSellStatusNot(Long wasteId, SellStatus sellStatus);
 
-    List<BuyerIdSummary> findBuyer_IdByWaste_IdAndBuyer_IdNot(Long wasteId, Long buyerId);
+    List<BuyerIdSummary> findBuyerIdByWasteIdAndBuyerIdNot(Long wasteId, Long buyerId);
 
     @EntityGraph(attributePaths = {"waste", "buyer", "seller", "chatMessages"})
     Optional<ChatRoom> findById(Long chatRoomId);

--- a/src/main/java/freshtrash/freshtrashbackend/repository/projections/BuyerIdSummary.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/projections/BuyerIdSummary.java
@@ -1,0 +1,3 @@
+package freshtrash.freshtrashbackend.repository.projections;
+
+public record BuyerIdSummary(Long buyerId) {}

--- a/src/main/java/freshtrash/freshtrashbackend/service/ChatRoomService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ChatRoomService.java
@@ -61,6 +61,6 @@ public class ChatRoomService {
     }
 
     public List<BuyerIdSummary> getBuyerIdByWasteId(Long wasteId, Long buyerId) {
-        return chatRoomRepository.findBuyer_IdByWaste_IdAndBuyer_IdNot(wasteId, buyerId);
+        return chatRoomRepository.findBuyerIdByWasteIdAndBuyerIdNot(wasteId, buyerId);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/ChatRoomService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ChatRoomService.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.exception.ChatException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.ChatRoomRepository;
+import freshtrash.freshtrashbackend.repository.projections.BuyerIdSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -57,5 +58,9 @@ public class ChatRoomService {
 
     public void closeChatRoom(Long chatRoomId) {
         chatRoomRepository.updateOpenOrClose(chatRoomId);
+    }
+
+    public List<BuyerIdSummary> getBuyerIdByWasteId(Long wasteId, Long buyerId) {
+        return chatRoomRepository.findBuyer_IdByWaste_IdAndBuyer_IdNot(wasteId, buyerId);
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요
- 채팅방에서 판매자가 예약중 선택시 : 폐기물, 채팅방 SellStatus가 Booking으로 수정되고 해당 채팅방 구매자에게 알림을 보냅니다.
- 채팅방에서 판매자가 판매중 선택시 : 폐기물, 채팅방 SellStatus가 Ongoing으로 수정되고 해당 폐기물에 채팅요청했던 구매자들에게 알림을 보냅니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 기존에 예약중 기능으로 구현되어 있던 TransactionApi의 updateBooking을 updateSellStatus로 판매중도 함께 처리할 수 있도록 변경 
  - @RequestParam SellStatus sellStatus 를 요청값에 넣었습니다.
  - 공통 : 폐기물, 채팅방의 SellStatus를 요청값으로 받은 sellStatus로 update합니다.
  - sellStatus = BOOKING 예약중인 경우 : 해당 채팅방의 구매자에게 예약중 알림을 보냅니다.
  - sellStatus = ONGOING 판매중인 경우 : 해당 폐기물에 채팅요청했던 다른 구매자들에게 판매중 알림을 보냅니다. (현재 채팅방 구매자는 제외)
  - 채팅요청했던 다른 구매자들 조회해올때 BuyerIdSummary 생성하여 projection적용하였습니다.
- 테스트 코드 수정

### API TEST
- http://localhost:8080/api/v1/transactions/chats/4/status?sellStatus=BOOKING 예약중 상태 요청
<img width="1248" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/82129206/3046c18d-6144-4fb0-9289-3a3f21694c01">
  - 해당 채팅방 구매자에게 예약중 알림 생성
<img width="1246" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/82129206/281421a4-51de-4a1a-8810-ca512fd9cf10">

- http://localhost:8080/api/v1/transactions/chats/4/status?sellStatus=ONGOING 판매중 상태 요청
<img width="1244" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/82129206/6026882d-150e-4517-add3-3a367bfe4896">
  - 폐기물 1번에 채팅요청했던 memberId 2,3,4 에게 알림 생성  
<img width="1223" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/82129206/5040c508-86b9-4157-8e30-6088dfd637fa">

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음 

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed : #123 
