### PR TITLE
알람 전송 기능에 적용한 RabbitMQ의 큐와 구조 변경

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,90 @@
+name: CI-CD
+
+on:
+  push:
+    branches:
+      - main
+
+# 워크플로의 모든 작업 단계에서 사용할 수 있는 변수
+env:
+  S3_BUCKET_NAME: fresh-trash-s3
+  YAML_PATH: ./src/main/resources/application-common.yml, ./src/main/resources/application-file.yml,  ./src/main/resources/application-mail.yml, ./src/main/resources/application-security.yml
+  CODE_DEPLOY_APPLICATION_NAME: CODE-DEPLOY-FRESH-TRASH
+  CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: CODE-DEPLOY-GROUP-FRESH-TRASH
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    # https://docs.github.com/ko/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses
+    # uses: 작업으로 실행할 재사용 가능한 워크플로 파일의 위치 및 버전
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+
+      - name: Set yaml file
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ${{ env.YAML_PATH }}
+        env:
+          spring.datasource.url: ${{ secrets.DB_URL }}
+          spring.datasource.username: ${{ secrets.DB_USERNAME }}
+          spring.datasource.password: ${{ secrets.DB_PASSWORD }}
+          spring.redis.port: ${{ secrets.REDIS_PORT }}
+          spring.redis.host: ${{ secrets.REDIS_HOST }}
+          local-file.absolute-path: ${{ secrets.LOCAL_FILE_ABS_PATH }}
+          aws.s3.bucket-name: ${{ secrets.S3_BUCKET_NAME }}
+          aws.s3.access-key: ${{ secrets.S3_ACCESS_KEY }}
+          aws.s3.secret-key: ${{ secrets.S3_SECRET_KEY }}
+          spring.mail.username: ${{ secrets.MAIL_USERNAME }}
+          spring.mail.password: ${{ secrets.MAIL_PASSWORD }}
+          validation.api-key: ${{ secrets.API_KEY }}
+          jwt.token.secret-key: ${{ secrets.TOKEN_SECRET_KEY }}
+          jwt.token.access-expired-ms: ${{ secrets.TOKEN_ACCESS_EXPIRED_MS }}
+          spring.security.oauth2.client.registration.google.client-id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          spring.security.oauth2.client.registration.google.client-secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          spring.security.oauth2.client.registration.naver.client-id: ${{ secrets.NAVER_OAUTH_CLIENT_ID }}
+          spring.security.oauth2.client.registration.naver.client-secret: ${{ secrets.NAVER_OAUTH_CLIENT_SECRET }}
+          spring.security.oauth2.client.registration.kakao.client-id: ${{ secrets.KAKAO_OAUTH_CLIENT_ID }}
+          spring.security.oauth2.client.registration.kakao.client-secret: ${{ secrets.KAKAO_OAUTH_CLIENT_SECRET }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        shell: bash
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+        shell: bash
+
+      # https://docs.github.com/ko/actions/learn-github-actions/variables#default-environment-variables
+      - name: Make zip file
+        run: zip -r ./$GITHUB_SHA .
+        shell: bash
+      
+      # https://github.com/aws-actions/configure-aws-credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      
+      # https://docs.aws.amazon.com/ko_kr/cli/latest/userguide/cli-services-s3-commands.html
+      # https://awscli.amazonaws.com/v2/documentation/api/latest/reference/index.html
+      - name: Upload to S3
+        run: aws s3 cp --region ap-northeast-2 ./$GITHUB_SHA.zip s3://$S3_BUCKET_NAME/$GITHUB_SHA.zip
+      
+      # https://docs.aws.amazon.com/ko_kr/codedeploy/latest/userguide/tutorials-github-deploy-application.html
+      # https://docs.aws.amazon.com/cli/latest/reference/deploy/create-deployment.html
+      - name: Code Deploy
+        run: |
+          aws deploy create-deployment \
+          --application-name ${{env.CODE_DEPLOY_APPLICATION_NAME}} \
+          --deployment-config-name CodeDeployDefault.AllAtOnce \
+          --deployment-group-name ${{env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME}} \
+          --s3-location bucket=$S3_BUCKET_NAME,bundleType=zip,key=$GITHUB_SHA.zip

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/ko_kr/codedeploy/latest/userguide/reference-appspec-file-structure.html#server-appspec-structure
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ubuntu/fresh-trash-backend
+    overwrite: yes
+
+permissions:
+  - object: /
+    pattern: "**"
+    owner: ubuntu
+    group: ubuntu
+
+hooks:
+  ApplicationStart:
+    - location: deploy_scripts/deploy_script.sh
+      timeout: 60
+      runas: ubuntu

--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -140,10 +140,10 @@ values (5, 1, 2, now()),
        (20, 1, 2, now());
 
 insert into alarms(member_id, alarm_type, alarm_args, message, created_at, read_at)
-values (1, 'CHAT', json_object('fromMemberId', '2', 'targetId', '1'), '거래 완료되었습니다.', now(), null),
-       (1, 'CHAT', json_object('fromMemberId', '1', 'targetId', '2'), '알람 테스트', now(), null),
-       (1, 'TRANSACTION', json_object('fromMemberId', '3', 'targetId', '1'), '예약 요청이 왔습니다. 수락 또는 거절 해주세요', now(), null),
-       (3, 'TRANSACTION', json_object('fromMemberId', '1', 'targetId', '1'), '예약이 거절되었습니다.', now(), null),
-       (2, 'TRANSACTION', json_object('fromMemberId', '3', 'targetId', '1'), '판매 완료되었습니다.', now(), null),
-       (3, 'TRANSACTION', json_object('fromMemberId', '2', 'targetId', '1'), '판매 완료되었습니다.', now(), null);
+values (1, 'CHAT', json_object('fromMemberId', 2, 'targetId', 1), '거래 완료되었습니다.', now(), null),
+       (1, 'CHAT', json_object('fromMemberId', 1, 'targetId', 2), '알람 테스트', now(), null),
+       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 1), '예약 요청이 왔습니다. 수락 또는 거절 해주세요', now(), null),
+       (3, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), '예약이 거절되었습니다.', now(), null),
+       (2, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 1), '판매 완료되었습니다.', now(), null),
+       (3, 'TRANSACTION', json_object('fromMemberId', 2, 'targetId', 1), '판매 완료되었습니다.', now(), null);
 

--- a/deploy_scripts/deploy_script.sh
+++ b/deploy_scripts/deploy_script.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+PROJECT_NAME="fresh-trash-backend"
+JAR_PATH="/home/ubuntu/$PROJECT_NAME/build/libs/*.jar"
+DEPLOY_PATH="/home/ubuntu/$PROJECT_NAME/"
+DEPLOY_LOG_PATH="/home/ubuntu/$PROJECT_NAME/deploy.log"
+DEPLOY_ERR_LOG_PATH="/home/ubuntu/$PROJECT_NAME/deploy_err.log"
+APPLICATION_LOG_PATH="/home/ubuntu/$PROJECT_NAME/application.log"
+BUILD_JAR=$(ls /home/ubuntu/fresh-trash-backend/build/libs/*.jar)
+JAR_NAME=$(basename $BUILD_JAR)
+STATIC_PATH="/home/ubuntu/$PROJECT_NAME/src/main/resources/static"
+
+echo "===== 배포 시작 : $(date +%c) =====" >> $DEPLOY_LOG_PATH
+
+echo "> build 파일명: $JAR_NAME" >> $DEPLOY_LOG_PATH
+echo "> build 파일 복사" >> $DEPLOY_LOG_PATH
+cp $BUILD_JAR $DEPLOY_PATH
+
+# -- Current Application Kill
+echo "> $CURRENT_PROFILE 에서 구동중인 애플리케이션 pid 확인" >> $DEPLOY_LOG_PATH
+CURRENT_PID=$(pgrep -f $JAR_NAME)
+
+if [ -z $CURRENT_PID ]
+then
+  echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다." >> $DEPLOY_LOG_PATH
+else
+  echo "> sudo kill -15 $CURRENT_PID" >> $DEPLOY_LOG_PATH
+  sudo kill -15 $CURRENT_PID
+  sleep 5
+fi
+
+# -- Deploy
+IDLE_PROFILE="prod"
+IDLE_APPLICATION_PATH=$DEPLOY_PATH$JAR_NAME
+
+echo "> $IDLE_PROFILE 배포" >> $DEPLOY_LOG_PATH
+nohup java -jar -DSpring.profiles.active=$IDLE_PROFILE $IDLE_APPLICATION_PATH >> $APPLICATION_LOG_PATH 2> $DEPLOY_ERR_LOG_PATH &
+
+sleep 3
+
+echo "> 배포 종료 : $(date +%c)" >> $DEPLOY_LOG_PATH

--- a/src/main/java/freshtrash/freshtrashbackend/config/AsyncConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/AsyncConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
 import java.util.concurrent.Executor;
 
 @EnableAsync
@@ -11,7 +12,7 @@ import java.util.concurrent.Executor;
 public class AsyncConfig {
 
     @Bean
-    public Executor getAsyncExecutor() {
+    public Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(5);
         executor.setMaxPoolSize(30);

--- a/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
@@ -1,26 +1,55 @@
 package freshtrash.freshtrashbackend.config;
 
+import freshtrash.freshtrashbackend.config.constants.QueueType;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static freshtrash.freshtrashbackend.config.constants.QueueType.*;
+
 @Configuration
 public class RabbitMQConfig {
-    public static final String WASTE_ID_KEY = "wasteId";
-    public static final String MEMBER_ID_KEY = "memberId";
-    public static final String FROM_MEMBER_ID_KEY = "fromMemberId";
-    public static final String WASTE_TRANSACTION_ROUTING_KEY = "waste.transaction";
-    public static final String ALARM_TYPE = "alarmType";
-    private static final String directExchangeName = "waste-direct-exchange";
-
-    private static final String WASTE_QUEUE = "waste-queue";
+    private static final String directExchangeName = "direct-exchange";
 
     @Bean
-    Queue wasteQueue() {
-        return new Queue(WASTE_QUEUE, false);
+    Queue wasteCompleteQueue() {
+        return createQueue(WASTE_TRANSACTION_COMPLETE);
+    }
+
+    @Bean
+    Queue wasteFlagQueue() {
+        return createQueue(WASTE_TRANSACTION_FLAG);
+    }
+
+    @Bean
+    Queue wasteChangeStatusQueue() {
+        return createQueue(WASTE_CHANGE_SELL_STATUS);
+    }
+
+    @Bean
+    Binding wasteCompleteBinding(Queue wasteCompleteQueue, DirectExchange directExchange) {
+        return BindingBuilder.bind(wasteCompleteQueue)
+                .to(directExchange)
+                .with(WASTE_TRANSACTION_COMPLETE.getRoutingKey());
+    }
+
+    @Bean
+    Binding wasteCancelBinding(Queue wasteFlagQueue, DirectExchange directExchange) {
+        return BindingBuilder.bind(wasteFlagQueue).to(directExchange).with(WASTE_TRANSACTION_FLAG.getRoutingKey());
+    }
+
+    @Bean
+    Binding wasteChangeStatusBinding(Queue wasteChangeStatusQueue, DirectExchange directExchange) {
+        return BindingBuilder.bind(wasteChangeStatusQueue)
+                .to(directExchange)
+                .with(WASTE_CHANGE_SELL_STATUS.getRoutingKey());
     }
 
     @Bean
@@ -29,7 +58,19 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    Binding directBinding(Queue queue, DirectExchange directExchange) {
-        return BindingBuilder.bind(queue).to(directExchange).with(WASTE_TRANSACTION_ROUTING_KEY);
+    RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter jackson2JsonMessageConverter) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setExchange(directExchangeName);
+        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter);
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public MessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    private Queue createQueue(QueueType queueType) {
+        return new Queue(queueType.getName(), false);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/config/constants/QueueType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/constants/QueueType.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.config.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum QueueType {
+    WASTE_TRANSACTION_COMPLETE("queue.waste.complete", "waste.transaction.complete"),
+    WASTE_CHANGE_SELL_STATUS("queue.waste.changeStatus", "waste.change.sellStatus"),
+    WASTE_TRANSACTION_FLAG("queue.waste.flag", "waste.transaction.flag");
+
+    private final String name;
+    private final String routingKey;
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/events/AlarmEvent.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/events/AlarmEvent.java
@@ -1,0 +1,16 @@
+package freshtrash.freshtrashbackend.dto.events;
+
+import freshtrash.freshtrashbackend.dto.request.MessageRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlarmEvent extends BaseEvent<MessageRequest> {
+    public AlarmEvent(String routingKey, MessageRequest payload) {
+        super(routingKey, payload);
+    }
+
+    public static AlarmEvent of(String routingKey, MessageRequest payload) {
+        return new AlarmEvent(routingKey, payload);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/events/BaseEvent.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/events/BaseEvent.java
@@ -1,0 +1,17 @@
+package freshtrash.freshtrashbackend.dto.events;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.MappedSuperclass;
+
+@Getter
+@MappedSuperclass
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEvent<T> {
+    protected String routingKey;
+    protected T payload;
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/AlarmResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/AlarmResponse.java
@@ -1,10 +1,18 @@
 package freshtrash.freshtrashbackend.dto.response;
 
+import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.entity.AlarmArgs;
 import freshtrash.freshtrashbackend.entity.constants.AlarmType;
+import lombok.Builder;
 
+@Builder
 public record AlarmResponse(Long id, AlarmType alarmType, AlarmArgs alarmArgs, String message) {
-    public static AlarmResponse of(Long id, AlarmType alarmType, AlarmArgs alarmArgs, String message) {
-        return new AlarmResponse(id, alarmType, alarmArgs, message);
+    public static AlarmResponse fromEntity(Alarm alarm) {
+        return AlarmResponse.builder()
+                .id(alarm.getId())
+                .alarmType(alarm.getAlarmType())
+                .alarmArgs(alarm.getAlarmArgs())
+                .message(alarm.getMessage())
+                .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
@@ -1,6 +1,6 @@
 package freshtrash.freshtrashbackend.entity;
 
-import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
+import freshtrash.freshtrashbackend.dto.request.MessageRequest;
 import freshtrash.freshtrashbackend.entity.audit.CreatedAt;
 import freshtrash.freshtrashbackend.entity.constants.AlarmType;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
@@ -56,7 +56,12 @@ public class Alarm extends CreatedAt {
         this.memberId = memberId;
     }
 
-    public AlarmResponse toResponse() {
-        return AlarmResponse.of(this.id, this.alarmType, this.alarmArgs, this.message);
+    public static Alarm fromMessageRequest(MessageRequest messageRequest) {
+        return Alarm.builder()
+                .message(messageRequest.message())
+                .memberId(messageRequest.memberId())
+                .alarmType(messageRequest.alarmType())
+                .alarmArgs(AlarmArgs.of(messageRequest.fromMemberId(), messageRequest.wasteId()))
+                .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -42,7 +42,7 @@ public class AlarmService {
     }
 
     /**
-     * 거래 완료 메시지 전송 Listener
+     * 알람 메시지 전송 Listener
      */
     @RabbitListener(queues = {"#{wasteCompleteQueue.name}", "#{wasteFlagQueue.name}", "#{wasteChangeStatusQueue.name}"})
     public void receiveWasteTransaction(@Payload MessageRequest messageRequest) {

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -1,6 +1,6 @@
 package freshtrash.freshtrashbackend.service;
 
-import freshtrash.freshtrashbackend.config.RabbitMQConfig;
+import freshtrash.freshtrashbackend.dto.request.MessageRequest;
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
 import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.entity.AlarmArgs;
@@ -11,18 +11,15 @@ import freshtrash.freshtrashbackend.repository.AlarmRepository;
 import freshtrash.freshtrashbackend.repository.EmitterRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Slf4j
 @Service
@@ -41,58 +38,33 @@ public class AlarmService {
     public Page<AlarmResponse> getAlarms(Long memberId, Pageable pageable) {
         return alarmRepository
                 .findAllByMember_IdAndReadAtIsNull(memberId, pageable)
-                .map(Alarm::toResponse);
-    }
-
-    /**
-     * 알람 저장
-     * - 폐기물 거래 완료 알람
-     * @param memberId 알람을 받는 사용자 id
-     * @param targetId 폐기물 id
-     * @param fromMemberId 알람을 보내는 사용자 id
-     * @param alarmType 알람 종류
-     */
-    public Alarm saveAlarm(String message, Long memberId, Long targetId, Long fromMemberId, AlarmType alarmType) {
-        return alarmRepository.save(Alarm.builder()
-                .alarmType(alarmType)
-                .alarmArgs(AlarmArgs.of(fromMemberId, targetId))
-                .message(message)
-                .memberId(memberId)
-                .build());
+                .map(AlarmResponse::fromEntity);
     }
 
     /**
      * 거래 완료 메시지 전송 Listener
      */
-    @RabbitListener(queues = "#{wasteQueue.name}")
-    public void receiveWasteTransaction(Message message) {
-        MessageProperties messageProperties = message.getMessageProperties();
-        receive(
-                new String(message.getBody(), UTF_8),
-                messageProperties.getHeader(RabbitMQConfig.MEMBER_ID_KEY),
-                messageProperties.getHeader(RabbitMQConfig.WASTE_ID_KEY),
-                messageProperties.getHeader(RabbitMQConfig.FROM_MEMBER_ID_KEY),
-                AlarmType.valueOf(messageProperties.getHeader(RabbitMQConfig.ALARM_TYPE)));
+    @RabbitListener(queues = {"#{wasteCompleteQueue.name}", "#{wasteFlagQueue.name}", "#{wasteChangeStatusQueue.name}"})
+    public void receiveWasteTransaction(@Payload MessageRequest messageRequest) {
+        log.debug("receive complete transaction message: {}", messageRequest);
+        Alarm alarm = saveAlarm(messageRequest);
+        receive(messageRequest.memberId(), AlarmResponse.fromEntity(alarm));
     }
 
     /**
      * SSE 알람 전송
      * @param memberId 알람을 받는 사용자 id
-     * @param targetId 폐기물 id
-     * @param fromMemberId 알람을 보내는 사용자 id
-     * @param alarmType 알람 종류
      */
-    private void receive(String message, Long memberId, Long targetId, Long fromMemberId, AlarmType alarmType) {
-        Alarm alarm = saveAlarm(message, memberId, targetId, fromMemberId, alarmType);
+    private void receive(Long memberId, AlarmResponse alarmResponse) {
         emitterRepository
                 .findByMemberId(memberId)
                 .ifPresentOrElse(
                         sseEmitter -> {
                             try {
                                 sseEmitter.send(SseEmitter.event()
-                                        .id(String.valueOf(alarm.getId()))
+                                        .id(String.valueOf(alarmResponse.id()))
                                         .name(WASTE_TRANSACTION_ALARM_NAME)
-                                        .data(alarm.toResponse()));
+                                        .data(alarmResponse));
                             } catch (IOException e) {
                                 emitterRepository.deleteByMemberId(memberId);
                                 throw new AlarmException(ErrorCode.ALARM_CONNECT_ERROR, e);
@@ -138,5 +110,27 @@ public class AlarmService {
 
     public boolean isOwnerOfAlarm(Long alarmId, Long memberId) {
         return alarmRepository.existsByIdAndMember_Id(alarmId, memberId);
+    }
+
+    private Alarm saveAlarm(MessageRequest messageRequest) {
+        return alarmRepository.save(Alarm.fromMessageRequest(messageRequest));
+    }
+
+    /**
+     * 알람 저장
+     * - 폐기물 거래 완료 알람
+     * @param memberId 알람을 받는 사용자 id
+     * @param targetId 폐기물 id
+     * @param fromMemberId 알람을 보내는 사용자 id
+     * @param alarmType 알람 종류
+     */
+    @Deprecated
+    private Alarm saveAlarm(String message, Long memberId, Long targetId, Long fromMemberId, AlarmType alarmType) {
+        return alarmRepository.save(Alarm.builder()
+                .alarmType(alarmType)
+                .alarmArgs(AlarmArgs.of(fromMemberId, targetId))
+                .message(message)
+                .memberId(memberId)
+                .build());
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/EventService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/EventService.java
@@ -1,0 +1,22 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.dto.events.BaseEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventService {
+    private final RabbitMqProducer rabbitMqProducer;
+
+    @Async
+    @EventListener(classes = BaseEvent.class)
+    public void handleEvent(BaseEvent<?> event) {
+        log.debug("handle event: {}", event);
+        rabbitMqProducer.publish(event);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/RabbitMqProducer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/RabbitMqProducer.java
@@ -1,0 +1,19 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.dto.events.BaseEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RabbitMqProducer {
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publish(BaseEvent<?> event) {
+        log.debug("rabbitmq publish: {}", event);
+        rabbitTemplate.convertAndSend(event.getRoutingKey(), event.getPayload());
+    }
+}

--- a/src/main/resources/application-amqp.yml
+++ b/src/main/resources/application-amqp.yml
@@ -1,0 +1,8 @@
+spring:
+  config.activate.on-profile: amqp
+  rabbitmq:
+    listener:
+      simple:
+        retry:
+          enabled: true
+          max-attempts: 3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
     group:
       local:
         - common
+        - amqp
         - file
         - mail
         - security
@@ -13,6 +14,7 @@ spring:
         - security
       prod:
         - common
+        - amqp
         - file
         - mail
         - security


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 폐기물 거래 완료, 상태 변경, 신고하기에 대한 MQ를 나누어서 분산 처리를 적용합니다. 또한 ApplicationEventPublisher를 사용하여 Event 객체를 비동기적으로 처리함으로써 효율성을 향상시키도록 합니다.

추가로 message publish 중 예외가 발생했을시 re-deliver가 되도록 SimpleRetryPolicy를 적용합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- AMQP의 SimpleRetryPolicy 적용
    - max-attempts를 3으로 설정하여 1초 간격으로 3회 재실행하도록 설정
    - SimpleRetryPolicy를 적용하지 않을 경우 예외가 발생했을 때 무한정 재실행하게됩니다.

- RabbitMQ 설정 변경
    - 거래완료, 상태변경, 신고하기에 대한 MQ를 분리하고 MessageConverter를 Jackson2JsonMessageConverter로 지정
    - MessageConverter를 따로 지정하지 않을 경우 byte array 형식으로 convert 됩니다.

- `ApplicationEventPublisher` 적용
    - Event(`AlarmEvent`) 객체를 정의하여 거래완료, 상태변경, 신고하기 로직이 수행될 때 ApplicationEventPublisher를 통해 처리되도 록 적용했습니다.
    - EventListener에 비동기 처리를 적용했습니다.

- 전체 구조

    ![Drawing 2024-05-01 01 39 26 excalidraw](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/5f0abb64-c0b7-4329-a762-536fc1f308fd)



## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- insert_data.sql의 알람 데이터에서 alarm_args에 들어있는 id 타입 변경
- Excuter 빈 이름이 잘못되어 수정(getTaskExecutor -> taskExecutor)
    - 빈 이름이 잘못되어 실제로 사용이 안되고 있었습니다.
- Alarm의 toResponse 메소드를 AlarmResponse에 전가

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #126 
