### PR TITLE
WebsocketStompBroker를 외부 브로커(RabbitMQ)로 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -6,6 +6,9 @@ services:
       dockerfile: Dockerfile
       context: ./rabbitmq
     image: fresh-trash-rabbitmq:0.1
+    environment:
+      - RABBITMQ_DEFAULT_USER=${AMQP_USER}
+      - RABBITMQ_DEFAULT_PASS=${AMQP_PASS}
     ports:
       - "15672:15672"
       - "61613:61613"

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -5,8 +5,10 @@ services:
     build:
       dockerfile: Dockerfile
       context: ./rabbitmq
-    image: rabbitmq:3
+    image: fresh-trash-rabbitmq:0.1
     ports:
+      - "15672:15672"
+      - "61613:61613"
       - "5672:5672"
     networks:
       - docker-redis

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,1 +1,4 @@
-FROM rabbitmq:3
+FROM rabbitmq:3-management
+RUN rabbitmq-plugins enable rabbitmq_management
+RUN rabbitmq-plugins enable rabbitmq_web_stomp
+RUN rabbitmq-plugins enable rabbitmq_stomp

--- a/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
@@ -1,10 +1,7 @@
 package freshtrash.freshtrashbackend.config;
 
 import freshtrash.freshtrashbackend.config.constants.QueueType;
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.DirectExchange;
-import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -17,6 +14,7 @@ import static freshtrash.freshtrashbackend.config.constants.QueueType.*;
 @Configuration
 public class RabbitMQConfig {
     private static final String directExchangeName = "direct-exchange";
+    private static final String topicExchangeName = "amq.topic";
 
     @Bean
     Queue wasteCompleteQueue() {
@@ -31,6 +29,11 @@ public class RabbitMQConfig {
     @Bean
     Queue wasteChangeStatusQueue() {
         return createQueue(WASTE_CHANGE_SELL_STATUS);
+    }
+
+    @Bean
+    Queue chatQueue() {
+        return createQueue(CHAT);
     }
 
     @Bean
@@ -53,8 +56,18 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    Binding topicBinding(Queue chatQueue, TopicExchange topicExchange) {
+        return BindingBuilder.bind(chatQueue).to(topicExchange).with(CHAT.getRoutingKey());
+    }
+
+    @Bean
     DirectExchange directExchange() {
         return new DirectExchange(directExchangeName);
+    }
+
+    @Bean
+    TopicExchange topicExchange() {
+        return new TopicExchange(topicExchangeName);
     }
 
     @Bean

--- a/src/main/java/freshtrash/freshtrashbackend/config/WebSocketConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/WebSocketConfig.java
@@ -12,14 +12,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // 클라이언트가 연결할 웹소켓 엔드포인트 설정
-        registry.addEndpoint("/chat-ws").setAllowedOrigins("http://localhost:5173");
+        registry.addEndpoint("/chat-ws").setAllowedOriginPatterns("*");
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // 메시지를 라우팅할 경로의 접두사 설정
-        registry.enableSimpleBroker("/chat");
+        registry.enableStompBrokerRelay("/topic");
         registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/config/WebSocketConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package freshtrash.freshtrashbackend.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -8,7 +10,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final RabbitProperties rabbitProperties;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -17,7 +21,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableStompBrokerRelay("/topic");
+        registry.enableStompBrokerRelay("/topic")
+                .setSystemLogin(rabbitProperties.getUsername())
+                .setSystemPasscode(rabbitProperties.getPassword())
+                .setClientLogin(rabbitProperties.getUsername())
+                .setClientPasscode(rabbitProperties.getPassword());
         registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/config/constants/QueueType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/constants/QueueType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum QueueType {
     WASTE_TRANSACTION_COMPLETE("queue.waste.complete", "waste.transaction.complete"),
     WASTE_CHANGE_SELL_STATUS("queue.waste.changeStatus", "waste.change.sellStatus"),
-    WASTE_TRANSACTION_FLAG("queue.waste.flag", "waste.transaction.flag");
+    WASTE_TRANSACTION_FLAG("queue.waste.flag", "waste.transaction.flag"),
+    CHAT("queue.chat", "chats.#");
 
     private final String name;
     private final String routingKey;

--- a/src/main/java/freshtrash/freshtrashbackend/controller/ChatMessageApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ChatMessageApi.java
@@ -20,7 +20,7 @@ public class ChatMessageApi {
      * @param memberId 메시지를 전송한 유저 id
      */
     @MessageMapping("/{chatRoomId}/message/{memberId}")
-    @SendTo("/chat/{chatRoomId}/message")
+    @SendTo("/topic/chats.{chatRoomId}")
     public ChatMessageResponse sendChatMessage(
             @DestinationVariable Long chatRoomId,
             @DestinationVariable Long memberId,

--- a/src/main/resources/application-amqp.yml
+++ b/src/main/resources/application-amqp.yml
@@ -1,6 +1,10 @@
 spring:
   config.activate.on-profile: amqp
   rabbitmq:
+    host: ${AMQP_HOST}
+    port: ${AMQP_PORT}
+    username: ${AMQP_USER}
+    password: ${AMQP_PASS}
     listener:
       simple:
         retry:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+  rabbitmq:
+    ssl:
+      enabled: true

--- a/src/main/resources/static/chat/chat_stomp.js
+++ b/src/main/resources/static/chat/chat_stomp.js
@@ -1,11 +1,14 @@
 const stompClient = new StompJs.Client({
-    brokerURL: 'ws://localhost:8080/chat-ws'
+    brokerURL: 'ws://localhost:8080/chat-ws',
+    debug: (str) => {
+        console.log(str)
+    },
 });
 
 stompClient.onConnect = (frame) => {
     setConnected(true);
     console.log('Connected: ' + frame);
-    stompClient.subscribe('/chat/1/message', (greeting) => {
+    stompClient.subscribe('/topic/chats.1', (greeting) => {
         console.log('subscribe: ' + JSON.stringify(greeting.body));
         showGreeting(JSON.parse(greeting.body).message);
         showGreeting(JSON.parse(greeting.body).sentMemberId);


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- StompBroker가 기존에 SimpleBroker로 지정되어있어 Application이 실행되는 서버에 종속적이다는 단점이 있습니다. scale-out 시 서버 간의 메시지 공유가 안되고 메시지 처리 역할을 RabbitMQ에 넘기면서 서버의 부담을 덜 수 있길 기대합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- WebSocket에 외부 브로커 RabbitMQ 적용
    - RabbitMQ 설정 변경
        - `amq.topic`이름을 가지는 topicExchange 추가
        - `chat-queue` 이름을 가지는 queue 추가
        - 추가한 queue와 exchange는 `chats.#` routing key로 바인딩
    - WebSocket 설정 변경
        - 외부 브로커 설정
        - destinationPrefix는 `/topic`으로 변경

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 웹소켓의 외부 브로커 사용을 위해 reactor-netty dependency 추가
- rabbitMq의 도커 설정 수정
    - 15672, 61613 포트 추가
        - 15672 포트는 브라우저에서 접근하여 설정 변경/모니터링 등을 할 수 있도록 추가했습니다.
            - localhost:51672 로 접속해서 rabbitmq.username/rabbitmq.password로 로그인
              ![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/db950e4a-6659-40c7-b7be-c0454f8c010c)
        - 61613 포트는 rabbitMq stomp 사용을 위해 추가했습니다. 
- 추가된 환경 변수들은 노션에 추가했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #128 
