### PR TITLE
docker-compose version 삭제

### DIFF
--- a/database/docker-compose-db.yml
+++ b/database/docker-compose-db.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   fresh-trash-database:
     container_name: fresh-trash-database

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,4 +1,3 @@
-version: "1"
 services:
   fresh-trash-rabbitmq:
     container_name: fresh-trash-rabbitmq


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- docker compose v2.25.0 부터 version을 사용하지 않기 때문에 삭제합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- docker-compose 파일의 version 삭제

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #135 