### PR TITLE
Redis의 OOM 문제를 해결하기위한 memory 설정 추가

### DIFF
--- a/database/docker-compose-db.yml
+++ b/database/docker-compose-db.yml
@@ -20,7 +20,7 @@ services:
     build:
       dockerfile: Dockerfile
       context: ./redis
-    image: redis:latest
+    image: fresh-trash-redis:0.1
     ports:
       - "6379:6379"
     networks:

--- a/database/redis/Dockerfile
+++ b/database/redis/Dockerfile
@@ -1,1 +1,3 @@
 FROM redis:latest
+COPY redis.conf /usr/local/etc/redis/redis.conf
+CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/database/redis/redis.conf
+++ b/database/redis/redis.conf
@@ -1,0 +1,10 @@
+maxmemory 512mb
+maxmemory-policy allkeys-lfu
+maxmemory-samples 5
+
+lfu-log-factor 10
+lfu-decay-time 1
+
+lazyfree-lazy-eviction yes
+lazyfree-lazy-expire yes
+lazyfree-lazy-user-del yes


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- Redis의 OOM 문제를 해결하기위한 memory 설정을 추가합니다. 자세한 내용은 #133 참고바랍니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- maxmemory
    - elasticache의 데모 옵션과 같은 용량인 512mb로 설정했습니다.
- maxmemory-policy
    - 가장 적게 사용한 캐시를 먼저 삭제할 수 있도록 `allkeys-lfu`를 설정했습니다.
    - lru로 설정할 경우 캐시가 오래되었더라도 꾸준히 사용되고 있을 경우를 고려하면 UX 관점에서 안좋은 영향을 줄 것이라 판단했습니다.
    - lfu의 경우 `lfu-decay-time`을 설정해주어 시간이 지남에따라 counter 값을 감소시킬 수 있습니다.
- lazyfree
    - eviction, expire 등 관련 key 삭제 수행 시 non-blocking으로 background에서 동작하도록 설정했습니다. 

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #133 
