### PR TITLE
RabbitMQ 설정 변경

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/aspect/BrokerSendAckAspect.java
+++ b/src/main/java/freshtrash/freshtrashbackend/aspect/BrokerSendAckAspect.java
@@ -1,0 +1,35 @@
+package freshtrash.freshtrashbackend.aspect;
+
+import com.rabbitmq.client.Channel;
+import freshtrash.freshtrashbackend.exception.AlarmException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class BrokerSendAckAspect {
+
+    @Pointcut("@annotation(freshtrash.freshtrashbackend.aspect.annotation.ManualAcknowledge)")
+    private void publishMessage() {}
+
+    @AfterReturning("publishMessage()")
+    public void sendAck(JoinPoint joinpoint) {
+        try {
+            Object[] args = joinpoint.getArgs();
+            Channel channel = (Channel) args[0];
+            long tag = (long) args[1];
+            channel.basicAck(tag, false);
+            log.debug(
+                    "Successfully send ack after \"{}\" method",
+                    joinpoint.getSignature().getName());
+        } catch (Exception e) {
+            throw new AlarmException(ErrorCode.FAILED_SEND_ACK_TO_BROKER);
+        }
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/aspect/annotation/ManualAcknowledge.java
+++ b/src/main/java/freshtrash/freshtrashbackend/aspect/annotation/ManualAcknowledge.java
@@ -1,0 +1,10 @@
+package freshtrash.freshtrashbackend.aspect.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ManualAcknowledge {}

--- a/src/main/java/freshtrash/freshtrashbackend/config/AsyncConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/AsyncConfig.java
@@ -7,8 +7,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 
-@EnableAsync
 @Configuration
+@EnableAsync(proxyTargetClass = true)
 public class AsyncConfig {
 
     @Bean
@@ -18,6 +18,8 @@ public class AsyncConfig {
         executor.setMaxPoolSize(30);
         executor.setQueueCapacity(60);
         executor.setThreadNamePrefix("async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
         executor.initialize();
         return executor;
     }

--- a/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
@@ -9,6 +9,9 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static freshtrash.freshtrashbackend.config.constants.QueueType.*;
 
 @Configuration
@@ -84,6 +87,8 @@ public class RabbitMQConfig {
     }
 
     private Queue createQueue(QueueType queueType) {
-        return new Queue(queueType.getName(), false);
+        Map<String, Object> args = new HashMap<String, Object>();
+        args.put("x-queue-version", 2);
+        return new Queue(queueType.getName(), true, false, false, args);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/RabbitMQConfig.java
@@ -1,6 +1,7 @@
 package freshtrash.freshtrashbackend.config;
 
 import freshtrash.freshtrashbackend.config.constants.QueueType;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -14,6 +15,7 @@ import java.util.Map;
 
 import static freshtrash.freshtrashbackend.config.constants.QueueType.*;
 
+@Slf4j
 @Configuration
 public class RabbitMQConfig {
     private static final String directExchangeName = "direct-exchange";
@@ -78,6 +80,11 @@ public class RabbitMQConfig {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setExchange(directExchangeName);
         rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter);
+        rabbitTemplate.setMandatory(true);
+        // 메시지가 브로커에 도착했지만 지정된 큐로 라우팅되지 못한 경우
+        rabbitTemplate.setReturnsCallback((returnedMessage) -> {
+            log.info("routingKey: {}, replyText: {}", returnedMessage.getRoutingKey(), returnedMessage.getReplyText());
+        });
         return rabbitTemplate;
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     // Alarm
     ALARM_CONNECT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알람을 위한 연결 시도 실패"),
     FORBIDDEN_ALARM(HttpStatus.FORBIDDEN, "알람에 대한 권한이 없습니다."),
+    FAILED_SEND_ACK_TO_BROKER(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 브로커로 ack를 전송하는데 실패했습니다."),
 
     // Chat
     NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),

--- a/src/main/java/freshtrash/freshtrashbackend/service/ChatRoomService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ChatRoomService.java
@@ -6,7 +6,6 @@ import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.exception.ChatException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.ChatRoomRepository;
-import freshtrash.freshtrashbackend.repository.projections.BuyerIdSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/resources/application-amqp.yml
+++ b/src/main/resources/application-amqp.yml
@@ -10,3 +10,5 @@ spring:
         retry:
           enabled: true
           max-attempts: 3
+        concurrency: 5
+        max-concurrency: 10

--- a/src/main/resources/application-amqp.yml
+++ b/src/main/resources/application-amqp.yml
@@ -12,3 +12,4 @@ spring:
           max-attempts: 3
         concurrency: 5
         max-concurrency: 10
+        acknowledge-mode: manual # default: auto

--- a/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.service;
 
+import com.rabbitmq.client.Channel;
 import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.Fixture.FixtureDto;
 import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
@@ -78,10 +79,12 @@ class AlarmServiceTest {
         Long memberId = alarmPayload.memberId();
         Alarm alarm = Alarm.fromMessageRequest(alarmPayload);
         SseEmitter sseEmitter = new SseEmitter(TimeUnit.MINUTES.toMillis(30));
+        Channel channel = mock(Channel.class);
+        long deliveryTag = 3;
         given(alarmRepository.save(eq(alarm))).willReturn(alarm);
         given(emitterRepository.findByMemberId(eq(memberId))).willReturn(Optional.of(sseEmitter));
         // whenxp
-        alarmService.receiveWasteTransaction(alarmPayload);
+        alarmService.receiveWasteTransaction(channel, deliveryTag, alarmPayload);
         ArgumentCaptor<Alarm> alarmCaptor = ArgumentCaptor.forClass(Alarm.class);
         // then
         verify(alarmRepository, times(1)).save(alarmCaptor.capture());


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
- 비동기 처리, 안전하게 consume/publish하기 위한 RabbitMQ의 설정이 필요합니다. 메시지를 처리하는 과정에서 메시지가 유실되지 않도록 설정에 반영하도록 합니다. 그 밖에 성능 개선을 위한 설정도 추가합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- Listener 비동기 처리 적용
    - 기본적으로 단일 consumer를 통해 메시지를 수신합니다. 비동기적으로 메시지를 수신함으로써 처리량을 향상시키도록 적용했습니다.
    - concurrency(5)와 max-concurrency(10) 값을 임의로 설정

- Durable 설정 및 Queue version 지정
    - durable 설정을 true로 지정하여 broker가 재시작해도 queue가삭제되지 않도록 적용 
    - queue version은 2로 지정하여 기본 classic queue보다 높은 성능을 가지도록 적용
        - [RabbitMQ 3.12 Performance Improvement](https://www.rabbitmq.com/blog/2023/05/17/rabbitmq-3.12-performance-improvements)에서 대부분의 경우 20 ~ 40%의 처리량 향상과 낮은 메모리 사용량이라는 결과를 얻었다고 합니다.

- `acknowledge-mode=manual` 설정 
    - `auto-ack=false`와 같은 의미로 acknowledge-mode를 manual로 설정 
        - 기본값은 auto이며 auto로 설정할 경우 `auto-ack=true`와 같습니다.
    - 메시지를 처리가 완료된 후 AOP를 통해 ack를 전송하도록 적용
        - `@ManualAcknowledge` 어노테이션을 추가하여 Aspect를 적용했습니다.
        - 이후 다른 서비스 로직에서 재사용하기위해 AOP를 적용했습니다.

- mandatory 설정
    - mandatory를 true로 설정하고 `ReturnsCallback`을 지정하여 라우팅되지 못한 메시지를 처리하도록 적용 
        - 임의로 log를 출력하도록 했고 이후 DLQ로 보내도록 반영할 예정입니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- Async의 CGLIB 프록시 사용 설정과 Graceful Shutdown 적용 
    - proxyTargetClass를 true로 설정하여 JDK dynamic proxy 보다 빠른 CGLIB 프록시 방식(바이트코드를 직접 조작)을 사용하도록 적용했습니다.
    - 메인 스레드가 종료되거나 인터럽트가 발생할 경우 모든 작업을 중지/반환하는 것을 방지하고 처리 중이었던 작업들을 계속 수행할 수 있도록 한 후 종료시키는 Graceful Shutdown 적용했습니다.

- 테스트 코드 수정

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #143 
