### PR TITLE
채팅관련 Nginx 설정 수정

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -9,7 +9,7 @@ upstream frontend {
 server {
     listen 80;
 
-    location /api {
+    location ~ /(api|chat-ws) {
         # preflight response
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' 'http://localhost:5173';
@@ -19,8 +19,10 @@ server {
             return 204;
         }
 
-        proxy_pass http://backend/api;
-        proxy_set_header Connection '';
+        rewrite ^/(.*)$ /$1 break;
+        proxy_pass http://backend/$1$is_args$args;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
         proxy_http_version 1.1;
         add_header 'Access-Control-Allow-Origin' 'http://localhost:5173' always;
         add_header 'Access-Control-Allow-Credentials' 'true';
@@ -28,7 +30,7 @@ server {
 
     location / {
         proxy_pass http://frontend;
-        proxy_set_header Connection '';
+        proxy_set_header Connection 'keep-alive';
         proxy_http_version 1.1;
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- Nginx 설정 후 프론트 쪽에서 채팅을 요청할 경우 에러가 발생하는 현상이 나타났습니다. 이는 Nginx에서 웹소켓관련 url이 처리되어있지 않기 때문입니다. Nginx 설정을 수정함으로써 해당 문제를 해결합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- api 요청(`/api`)과 채팅 연결 요청(`/chat-ws`)을 하나의 location으로 설정하기위해 regex를 이용했습니다.

```
location ~ /(api|chat-ws) {
        rewrite ^/(.*)$ /$1 break;
        proxy_pass http://backend/$1;
}
```

- WebSocket 사용을 위해 Upgrade, Connection 헤더를 수정/추가했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Fixed: #145 
