### PR TITLE
관심 목록 조회 시 카테고리 검색 적용

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/WasteLikeApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/WasteLikeApi.java
@@ -1,9 +1,12 @@
 package freshtrash.freshtrashbackend.controller;
 
+import com.querydsl.core.types.Predicate;
 import freshtrash.freshtrashbackend.controller.constants.LikeStatus;
 import freshtrash.freshtrashbackend.dto.response.ApiResponse;
 import freshtrash.freshtrashbackend.dto.response.WasteResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.QWasteLike;
+import freshtrash.freshtrashbackend.entity.WasteLike;
 import freshtrash.freshtrashbackend.exception.WasteException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.service.WasteLikeService;
@@ -11,6 +14,7 @@ import freshtrash.freshtrashbackend.service.WasteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,9 +32,12 @@ public class WasteLikeApi {
 
     @GetMapping("/likes")
     public ResponseEntity<Page<WasteResponse>> getLikedWastes(
+            @QuerydslPredicate(root = WasteLike.class) Predicate predicate,
             @PageableDefault(size = 6, sort = "createdAt", direction = DESC) Pageable pageable,
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        Page<WasteResponse> wastes = wasteLikeService.getLikedWastes(memberPrincipal.id(), pageable);
+
+        predicate = QWasteLike.wasteLike.memberId.eq(memberPrincipal.id()).and(predicate);
+        Page<WasteResponse> wastes = wasteLikeService.getLikedWastes(predicate, pageable);
         return ResponseEntity.ok(wastes);
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteLikeRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteLikeRepository.java
@@ -1,19 +1,36 @@
 package freshtrash.freshtrashbackend.repository;
 
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.EnumExpression;
+import freshtrash.freshtrashbackend.entity.QWasteLike;
 import freshtrash.freshtrashbackend.entity.WasteLike;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(propagation = Propagation.SUPPORTS)
-public interface WasteLikeRepository extends JpaRepository<WasteLike, Long> {
+public interface WasteLikeRepository
+        extends JpaRepository<WasteLike, Long>,
+                QuerydslPredicateExecutor<WasteLike>,
+                QuerydslBinderCustomizer<QWasteLike> {
+
+    @Override
+    default void customize(QuerydslBindings bindings, QWasteLike root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.waste.wasteCategory);
+        bindings.bind(root.waste.wasteCategory).as("category").first(EnumExpression::eq);
+    }
+
     boolean existsByMemberIdAndWasteId(Long memberId, Long wasteId);
 
     void deleteByMemberIdAndWasteId(Long memberId, Long wasteId);
 
     @EntityGraph(attributePaths = {"waste", "waste.member"})
-    Page<WasteLike> findAllByMember_Id(Long memberId, Pageable pageable);
+    Page<WasteLike> findAll(Predicate predicate, Pageable pageable);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/WasteRepository.java
@@ -36,9 +36,6 @@ public interface WasteRepository
     @EntityGraph(attributePaths = "member")
     Optional<Waste> findById(Long wasteId);
 
-    @Query("select w.member from Waste w where w.id = ?1")
-    Optional<Member> findSellerById(Long wasteId);
-
     Optional<FileNameSummary> findFileNameById(Long wasteId);
 
     boolean existsByIdAndMember_Id(Long wasteId, Long memberId);

--- a/src/main/java/freshtrash/freshtrashbackend/service/WasteLikeService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/WasteLikeService.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.service;
 
+import com.querydsl.core.types.Predicate;
 import freshtrash.freshtrashbackend.dto.response.WasteResponse;
 import freshtrash.freshtrashbackend.entity.WasteLike;
 import freshtrash.freshtrashbackend.exception.WasteException;
@@ -18,9 +19,9 @@ public class WasteLikeService {
     private final WasteLikeRepository wasteLikeRepository;
     private final WasteRepository wasteRepository;
 
-    public Page<WasteResponse> getLikedWastes(Long memberId, Pageable pageable) {
+    public Page<WasteResponse> getLikedWastes(Predicate predicate, Pageable pageable) {
         return wasteLikeRepository
-                .findAllByMember_Id(memberId, pageable)
+                .findAll(predicate, pageable)
                 .map(WasteLike::getWaste)
                 .map(WasteResponse::fromEntity);
     }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/WasteLikeApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/WasteLikeApiTest.java
@@ -1,8 +1,10 @@
 package freshtrash.freshtrashbackend.controller;
 
+import com.querydsl.core.types.Predicate;
 import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.config.TestSecurityConfig;
 import freshtrash.freshtrashbackend.dto.response.WasteResponse;
+import freshtrash.freshtrashbackend.entity.constants.WasteCategory;
 import freshtrash.freshtrashbackend.service.WasteLikeService;
 import freshtrash.freshtrashbackend.service.WasteService;
 import org.junit.jupiter.api.DisplayName;
@@ -12,8 +14,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -26,6 +31,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(WasteLikeApi.class)
 @Import(TestSecurityConfig.class)
 class WasteLikeApiTest {
@@ -43,11 +49,12 @@ class WasteLikeApiTest {
     @WithUserDetails(value = "testUser@gmail.com", setupBefore = TEST_EXECUTION)
     void given_loginUserAndPageable_when_getLikedWastes_then_returnPagingWasteData() throws Exception {
         // given
-        Long memberId = 123L;
-        given(wasteLikeService.getLikedWastes(eq(memberId), any(Pageable.class)))
+        WasteCategory category = WasteCategory.BEAUTY;
+        Pageable pageable = PageRequest.of(0, 6, Sort.Direction.DESC, "createdAt");
+        given(wasteLikeService.getLikedWastes(any(Predicate.class), eq(pageable)))
                 .willReturn(new PageImpl<>(List.of(WasteResponse.fromEntity(Fixture.createWaste()))));
         // when
-        mvc.perform(get("/api/v1/wastes/likes"))
+        mvc.perform(get("/api/v1/wastes/likes").queryParam("category", category.name()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.numberOfElements").value(1));
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/service/WasteLikeServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/WasteLikeServiceTest.java
@@ -1,7 +1,10 @@
 package freshtrash.freshtrashbackend.service;
 
+import com.querydsl.core.types.Predicate;
 import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.dto.response.WasteResponse;
+import freshtrash.freshtrashbackend.entity.QWasteLike;
+import freshtrash.freshtrashbackend.entity.constants.WasteCategory;
 import freshtrash.freshtrashbackend.repository.WasteLikeRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,10 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -20,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class WasteLikeServiceTest {
 
@@ -34,12 +36,15 @@ class WasteLikeServiceTest {
     void given_memberIdAndPageable_when_getWasteLikes_then_convertToWasteResponse() {
         // given
         Long memberId = 1L;
+        WasteCategory category = WasteCategory.BEAUTY;
         int expectedSize = 1;
-        Pageable pageable = PageRequest.of(0, 10);
-        given(wasteLikeRepository.findAllByMember_Id(eq(memberId), eq(pageable)))
+        Predicate predicate =
+                QWasteLike.wasteLike.memberId.eq(memberId).and(QWasteLike.wasteLike.waste.wasteCategory.eq(category));
+        Pageable pageable = PageRequest.of(0, 6, Sort.Direction.DESC, "createdAt");
+        given(wasteLikeRepository.findAll(eq(predicate), eq(pageable)))
                 .willReturn(new PageImpl<>(List.of(Fixture.createWasteLike())));
         // when
-        Page<WasteResponse> wastes = wasteLikeService.getLikedWastes(memberId, pageable);
+        Page<WasteResponse> wastes = wasteLikeService.getLikedWastes(predicate, pageable);
         // then
         assertThat(wastes.getSize()).isEqualTo(expectedSize);
     }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 요구사항 추가에 따라 중고 상품 목록 조회에서 처럼 관심 목록 조회에서도 카테고리 검색 기능을 추가합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항
- 관심 목록 조회 시 카테고리 검색 기능 추가
    - QueryDSL의 Predicate를 사용하여 카테고리를 Query Parameter로 받도록 했습니다. 
    - 카테고리는 `wasteLike.waste.wasteCategory` 와 바인딩합니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 테스트 코드 수정
- WasteRepository에 사용하지 않는 메소드 삭제

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #149 