### PR TITLE
사용자 신고 기능 수정

### DIFF
--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -1,16 +1,18 @@
 insert into members(email, password, rating, nickname, address, file_name, login_type, user_role, account_status,
-                    created_at, modified_at)
+                    created_at, modified_at, flag_count)
 values ('abc@never.com', '$2a$10$ZskRs64yZZU9g6blmNdZte7FO6KaMduwlZhk7YkxJX2ZwYLSrPfA.', 5, 'abc',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
-        'test.png', 'EMAIL', 'USER', 'ACTIVE', now(), null),
+        'test.png', 'EMAIL', 'USER', 'ACTIVE', now(), null, 0),
        ('def@never.com', '$2a$10$6UF8CDeP2A7ACjMVE/cpS.DlgRw/ZRA0NuHFnpziEpbasOhS6EGq.', 4, 'def',
-        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null),
+        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null, 0),
        ('user123@never.com', '$2a$10$6UF8CDeP2A7ACjMVE/cpS.DlgRw/ZRA0NuHFnpziEpbasOhS6EGq.', 3, 'user123',
-        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null),
+        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null, 0),
        ('user456@never.com', '$2a$10$6UF8CDeP2A7ACjMVE/cpS.DlgRw/ZRA0NuHFnpziEpbasOhS6EGq.', 2, 'user456',
-        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null),
+        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null, 0),
        ('user777@never.com', '$2a$10$6UF8CDeP2A7ACjMVE/cpS.DlgRw/ZRA0NuHFnpziEpbasOhS6EGq.', 2, 'user777',
-        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null);
+        null, null, 'EMAIL', 'USER', 'ACTIVE', now(), null, 0),
+       ('blackUser@gmail.com', '$2a$10$6UF8CDeP2A7ACjMVE/cpS.DlgRw/ZRA0NuHFnpziEpbasOhS6EGq.', 2, 'blackUser',
+        null, null, 'EMAIL', 'BLACK_USER', 'ACTIVE', now(), null, 10);
 
 
 insert into wastes(member_id, title, content, waste_price, like_count, view_count, file_name, waste_category,
@@ -151,11 +153,13 @@ values (1, 'CHAT', json_object('fromMemberId', 2, 'targetId', 1), '거래 완료
        (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 1), '거래 완료되었습니다.', now(), null),
        (1, 'TRANSACTION', json_object('fromMemberId', 4, 'targetId', 4), '예약중으로 변경하였습니다.', now(), null),
        (1, 'TRANSACTION', json_object('fromMemberId', 4, 'targetId', 4), '거래 완료되었습니다.', now(), null),
-       (1, 'FLAG', json_object('fromMemberId', 1, 'targetId', 1), '1번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다.', now(), null),
+       (1, 'FLAG', json_object('fromMemberId', 1, 'targetId', 1),
+        '1번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다.', now(), null),
        (2, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), 'abc님이 판매중으로 변경하였습니다.', now(), null),
        (2, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), '판매 완료되었습니다.', now(), null),
        (2, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), '판매 완료되었습니다.', now(), null),
-       (2, 'FLAG', json_object('fromMemberId', 1, 'targetId', 1), '1번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다.', now(), null),
+       (2, 'FLAG', json_object('fromMemberId', 1, 'targetId', 1),
+        '1번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다.', now(), null),
        (2, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 2), 'user123님이 예약중으로 변경했습니다.', now(), null),
        (2, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 2), '판매 완료되었습니다.', now(), null),
        (2, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 1), '판매 완료되었습니다.', now(), null),

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/AccountStatus.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/AccountStatus.java
@@ -2,6 +2,5 @@ package freshtrash.freshtrashbackend.entity.constants;
 
 public enum AccountStatus {
     ACTIVE,
-    INACTIVE,
-    BLOCK
+    INACTIVE
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/UserRole.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/UserRole.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum UserRole {
     USER("ROLE_USER"),
+    BLACK_USER("ROLE_BLACK_USER"),
     ADMIN("ROLE_ADMIN"),
     ANONYMOUS("ROLE_ANONYMOUS");
 

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -38,7 +38,6 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "유저 정보가 존재하지 않습니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
-    EXCEED_FLAG_COUNT(HttpStatus.BAD_REQUEST, "10번 이상 신고 당한 내역이 있기 때문에 해당 사이트 이용이 불가합니다."),
 
     // Alarm
     ALARM_CONNECT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알람을 위한 연결 시도 실패"),

--- a/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
@@ -1,8 +1,9 @@
 package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.Member;
-import freshtrash.freshtrashbackend.repository.projections.FlagCountSummary;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
+import freshtrash.freshtrashbackend.repository.projections.FlagCountSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Propagation;
@@ -16,14 +17,17 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Optional<FlagCountSummary> findFlagCountById(Long memberId);
+
+    Optional<FileNameSummary> findFileNameById(Long memberId);
+
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
 
-    Optional<FileNameSummary> findFileNameById(Long memberId);
-
     @Query(nativeQuery = true, value = "update members m set m.flag_count = m.flag_count + 1 where m.id = ?1")
     void updateFlagCount(Long memberId);
 
-    Optional<FlagCountSummary> findFlagCountById(Long memberId);
+    @Query(nativeQuery = true, value = "update members m set m.user_role = ?2 where m.id = ?1")
+    void updateUserRoleById(Long targetMemberId, UserRole userRole);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
@@ -25,8 +25,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
 
-    @Query(nativeQuery = true, value = "update members m set m.flag_count = m.flag_count + 1 where m.id = ?1")
-    void updateFlagCount(Long memberId);
+    @Query(nativeQuery = true, value = """
+            update members m 
+            set m.flag_count = m.flag_count + 1, 
+                m.user_role = case 
+                    when m.flag_count >= ?2 then 'BLACK_USER' 
+                    else m.user_role 
+                end 
+            where m.id = ?1
+            """)
+    void updateFlagCount(Long memberId, int flagLimit);
 
     @Query(nativeQuery = true, value = "update members m set m.user_role = ?2 where m.id = ?1")
     void updateUserRoleById(Long targetMemberId, UserRole userRole);

--- a/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
@@ -20,9 +20,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
-import org.springframework.web.cors.CorsConfiguration;
 
-import java.util.Collections;
 import java.util.UUID;
 
 @Configuration
@@ -51,7 +49,7 @@ public class SecurityConfig {
                         .regexMatchers(".*wastes", "/chat-ws", ".*auth/check-nickname.*")
                         .permitAll()
                         .anyRequest()
-                        .authenticated())
+                        .hasAnyRole("USER", "ADMIN"))
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()

--- a/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
@@ -4,6 +4,7 @@ import freshtrash.freshtrashbackend.dto.request.MemberRequest;
 import freshtrash.freshtrashbackend.dto.response.LoginResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Member;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.exception.AuthException;
 import freshtrash.freshtrashbackend.exception.MemberException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
@@ -29,7 +30,6 @@ public class MemberService {
     private final PasswordEncoder encoder;
     private final TokenProvider tokenProvider;
     private final FileService fileService;
-    private final int FLAG_LIMIT = 10;
 
     public Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
@@ -61,11 +61,6 @@ public class MemberService {
     public LoginResponse signIn(String email, String password) {
         Member member = getMemberByEmail(email);
         checkPassword(password, member.getPassword());
-
-        // 신고당한 횟수 10이상 -> 로그인 불가
-        if (member.getFlagCount() >= FLAG_LIMIT) {
-            throw new MemberException(ErrorCode.EXCEED_FLAG_COUNT);
-        }
 
         // 토큰 발급
         String accessToken = tokenProvider.generateAccessToken(member.getId());
@@ -153,5 +148,12 @@ public class MemberService {
         if (!encoder.matches(inputPassword, existPassword)) {
             throw new AuthException("not matched password");
         }
+    }
+
+    /**
+     * 대상 유저의 UserRole 변경
+     */
+    public void updateMemberRole(Long targetMemberId, UserRole userRole) {
+        memberRepository.updateUserRoleById(targetMemberId, userRole);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
@@ -4,7 +4,6 @@ import freshtrash.freshtrashbackend.dto.request.MemberRequest;
 import freshtrash.freshtrashbackend.dto.response.LoginResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Member;
-import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.exception.AuthException;
 import freshtrash.freshtrashbackend.exception.MemberException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
@@ -126,8 +125,8 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
-    public FlagCountSummary updateFlagCount(Long memberId) {
-        memberRepository.updateFlagCount(memberId);
+    public FlagCountSummary updateFlagCount(Long memberId, int flagLimit) {
+        memberRepository.updateFlagCount(memberId, flagLimit);
         return memberRepository
                 .findFlagCountById(memberId)
                 .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
@@ -148,12 +147,5 @@ public class MemberService {
         if (!encoder.matches(inputPassword, existPassword)) {
             throw new AuthException("not matched password");
         }
-    }
-
-    /**
-     * 대상 유저의 UserRole 변경
-     */
-    public void updateMemberRole(Long targetMemberId, UserRole userRole) {
-        memberRepository.updateUserRoleById(targetMemberId, userRole);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
@@ -1,6 +1,5 @@
 package freshtrash.freshtrashbackend.service.alarm;
 
-import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.service.MemberService;
 import freshtrash.freshtrashbackend.service.producer.ChatProducer;
 import org.springframework.stereotype.Component;
@@ -22,9 +21,7 @@ public class UserFlagChatAlarm extends ChatAlarmTemplate {
      */
     @Override
     int update(Long targetMemberId) {
-        int flagCount = this.memberService.updateFlagCount(targetMemberId).flagCount();
-        if (flagCount >= FLAG_LIMIT) this.memberService.updateMemberRole(targetMemberId, UserRole.BLACK_USER);
-        return flagCount;
+        return this.memberService.updateFlagCount(targetMemberId, FLAG_LIMIT).flagCount();
     }
 
     @Override

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
@@ -10,7 +10,7 @@ import static freshtrash.freshtrashbackend.dto.constants.AlarmMessage.FLAG_MESSA
 @Component
 public class UserFlagChatAlarm extends ChatAlarmTemplate {
 
-    private static int FLAG_LIMIT = 10;
+    private static final int FLAG_LIMIT = 10;
 
     public UserFlagChatAlarm(MemberService memberService, ChatProducer producer) {
         super(memberService, producer);

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.service.alarm;
 
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.service.MemberService;
 import freshtrash.freshtrashbackend.service.producer.ChatProducer;
 import org.springframework.stereotype.Component;
@@ -10,6 +11,8 @@ import static freshtrash.freshtrashbackend.dto.constants.AlarmMessage.FLAG_MESSA
 @Component
 public class UserFlagChatAlarm extends ChatAlarmTemplate {
 
+    private static int FLAG_LIMIT = 10;
+
     public UserFlagChatAlarm(MemberService memberService, ChatProducer producer) {
         super(memberService, producer);
     }
@@ -19,7 +22,9 @@ public class UserFlagChatAlarm extends ChatAlarmTemplate {
      */
     @Override
     int update(Long targetMemberId) {
-        return this.memberService.updateFlagCount(targetMemberId).flagCount();
+        int flagCount = this.memberService.updateFlagCount(targetMemberId).flagCount();
+        if (flagCount >= FLAG_LIMIT) this.memberService.updateMemberRole(targetMemberId, UserRole.BLACK_USER);
+        return flagCount;
     }
 
     @Override
@@ -29,6 +34,8 @@ public class UserFlagChatAlarm extends ChatAlarmTemplate {
     }
 
     private String generateMessage(int flagCount) {
-        return flagCount >= 10 ? EXCEED_FLAG_MESSAGE.getMessage() : String.format(FLAG_MESSAGE.getMessage(), flagCount);
+        return flagCount >= FLAG_LIMIT
+                ? EXCEED_FLAG_MESSAGE.getMessage()
+                : String.format(FLAG_MESSAGE.getMessage(), flagCount);
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -43,19 +43,13 @@ public class Fixture {
     }
 
     public static Member createMember(
-            Long id,
-            String email,
-            String password,
-            String nickname,
-            LoginType loginType,
-            UserRole userRole,
-            AccountStatus accountStatus) {
+            Long id, String email, String password, String nickname, LoginType loginType, AccountStatus accountStatus) {
         Member member = Member.builder()
                 .email(email)
                 .password(password)
                 .nickname(nickname)
                 .loginType(loginType)
-                .userRole(userRole)
+                .userRole(UserRole.USER)
                 .accountStatus(accountStatus)
                 .build();
 
@@ -67,7 +61,7 @@ public class Fixture {
     }
 
     public static Member createMember() {
-        return createMember(1L, "test@gmail.com", "pw", "test", LoginType.EMAIL, UserRole.USER, AccountStatus.ACTIVE);
+        return createMember(1L, "test@gmail.com", "pw", "test", LoginType.EMAIL, AccountStatus.ACTIVE);
     }
 
     public static ChatRoom createChatRoom(
@@ -106,25 +100,11 @@ public class Fixture {
         ReflectionTestUtils.setField(
                 chatRoom,
                 "seller",
-                createMember(
-                        sellerId,
-                        "seller@gmail.com",
-                        "pw",
-                        "seller",
-                        LoginType.EMAIL,
-                        UserRole.USER,
-                        AccountStatus.ACTIVE));
+                createMember(sellerId, "seller@gmail.com", "pw", "seller", LoginType.EMAIL, AccountStatus.ACTIVE));
         ReflectionTestUtils.setField(
                 chatRoom,
                 "buyer",
-                createMember(
-                        buyerId,
-                        "buyer@gmail.com",
-                        "pw",
-                        "buyer",
-                        LoginType.EMAIL,
-                        UserRole.USER,
-                        AccountStatus.ACTIVE));
+                createMember(buyerId, "buyer@gmail.com", "pw", "buyer", LoginType.EMAIL, AccountStatus.ACTIVE));
         ReflectionTestUtils.setField(chatRoom, "chatMessages", Set.of(createChatMessage()));
         return chatRoom;
     }

--- a/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
+++ b/src/test/java/freshtrash/freshtrashbackend/config/TestSecurityConfig.java
@@ -4,7 +4,6 @@ import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.entity.constants.AccountStatus;
 import freshtrash.freshtrashbackend.entity.constants.LoginType;
-import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.security.CustomOAuth2SuccessHandler;
 import freshtrash.freshtrashbackend.security.Http401UnauthorizedAuthenticationEntryPoint;
 import freshtrash.freshtrashbackend.security.SecurityConfig;
@@ -31,14 +30,13 @@ public class TestSecurityConfig {
     @MockBean
     private CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 
-
     @BeforeTestMethod
     void securitySetUp() {
         String userEmail = "testUser@gmail.com";
-        given(memberService.getMemberByEmail(eq(userEmail))).willReturn(createMember(userEmail));
+        given(memberService.getMemberByEmail(eq(userEmail))).willReturn(createMember(123L, userEmail));
     }
 
-    private Member createMember(String email) {
-        return Fixture.createMember(123L, email, "pw", "testUser", LoginType.EMAIL, UserRole.USER, AccountStatus.ACTIVE);
+    private Member createMember(Long id, String email) {
+        return Fixture.createMember(id, email, "pw", email.split("@")[0], LoginType.EMAIL, AccountStatus.ACTIVE);
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/WasteApiTest.java
@@ -39,7 +39,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.security.test.context.support.TestExecutionEvent.TEST_EXECUTION;


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 사용자가 일정 신고 횟수 이상 신고받을 경우 서비스를 이용할 수 없도록 적용해야합니다. 하지만 현재 서비스를 이용할 수 없다는 알림만 전송하고 실제로 이용할 수 없도록 적용되어있지 않습니다. 따라서 사용자가 일정 횟수 이상 신고를 받을 경우 UserRole을 변경시키고 인증이 필요한 모든 서비스에 접근하지 못하도록 설정해야합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- 유저 신고 이벤트를 처리할 때 신고 받은 유저의 총 신고 횟수가 일정 횟수 이상이 되면 UserRole을 `BLACK_USER`로 변경
    - 기존에 `BLACK_USER`가 없었기 때문에 추가했습니다.
    - 원자성을 유지하기 위햇 flag_count를 update하는 쿼리에서 `case ~ when ~ then` 구문을 추가하여 flag_count가 일정 횟수 이상이 되었을 경우 user_role을 `BLACK_USER`로 업데이트하도록 했고, 이하일 경우 원래 user_role을 그대로 지정하도록 적용했습니다.

- AccountStatus의 `BLOCK` 값은 사용하지 않으므로 삭제

- `MemberService.signIn()`에서 로그인을 못하게했던 로직은 삭제
    - `EXCEED_FLAG_COUNT` 에러 코드가 다른 곳에서 사용이 안되기 때문에 로직을 삭제하면서 같이 삭제했습니다. 

- SecurityConfig 설정 수정
    - 인증이 필요한 request는 `USER/ADMIN` role에 대해서 접근이 가능하도록 설정하고, `BLACK_USER/ANONYMOUS`에 대해서는 접근이 불가하도록 설정했습니다. 따라서 `BLACK_USER/ANONYMOUS` role을 가지는 유저가 접근하게되면 FORBIDDEN 에러가 발생합니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분
> 없으면 "없음" 이라고 기재해 주세요
- 테스트 코드 수정
- BLACK_USER인 Member 데이터 추가

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #151 
