### PR TITLE
경매 추가/삭제/조회 기능 구현

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AlarmApi.java
@@ -2,8 +2,6 @@ package freshtrash.freshtrashbackend.controller;
 
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
-import freshtrash.freshtrashbackend.exception.AlarmException;
-import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.service.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -43,15 +41,7 @@ public class AlarmApi {
     @PutMapping("/{alarmId}")
     public ResponseEntity<Void> readAlarm(
             @PathVariable Long alarmId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        checkIfOwnerOfAlarm(alarmId, memberPrincipal.id());
-        alarmService.readAlarm(alarmId);
+        alarmService.readAlarm(alarmId, memberPrincipal.id());
         return ResponseEntity.ok(null);
-    }
-
-    /**
-     * 로그인한 사용자가 대상 알람의 주인인지 확인
-     */
-    private void checkIfOwnerOfAlarm(Long alarmId, Long memberId) {
-        if (!alarmService.isOwnerOfAlarm(alarmId, memberId)) throw new AlarmException(ErrorCode.FORBIDDEN_ALARM);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
@@ -1,0 +1,69 @@
+package freshtrash.freshtrashbackend.controller;
+
+import com.querydsl.core.types.Predicate;
+import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
+import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
+import freshtrash.freshtrashbackend.exception.AuctionException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.service.AuctionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auctions")
+public class AuctionApi {
+    private final AuctionService auctionService;
+
+    @GetMapping
+    public ResponseEntity<Page<AuctionResponse>> getAuctions(
+            @QuerydslPredicate(root = Auction.class) Predicate predicate,
+            @PageableDefault(size = 6, sort = "createdAt", direction = DESC) Pageable pageable) {
+        Page<AuctionResponse> auctions = auctionService.getAuctions(predicate, pageable);
+        return ResponseEntity.ok(auctions);
+    }
+
+    @GetMapping("/{auctionId}")
+    public ResponseEntity<AuctionResponse> getAuction(@PathVariable Long auctionId) {
+        AuctionResponse auctionResponse = AuctionResponse.fromEntity(auctionService.getAuction(auctionId));
+        return ResponseEntity.ok(auctionResponse);
+    }
+
+    @PostMapping
+    public ResponseEntity<AuctionResponse> addAuction(
+            @RequestPart MultipartFile imgFile,
+            @RequestPart @Valid AuctionRequest auctionRequest,
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        AuctionResponse auctionResponse = auctionService.addAuction(imgFile, auctionRequest, memberPrincipal);
+        return ResponseEntity.status(HttpStatus.CREATED).body(auctionResponse);
+    }
+
+    @DeleteMapping("/{auctionId}")
+    public ResponseEntity<Void> deleteAuction(
+            @PathVariable Long auctionId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        checkIfWriterOrAdmin(memberPrincipal, auctionId);
+        auctionService.deleteAuction(auctionId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+    }
+
+    private void checkIfWriterOrAdmin(MemberPrincipal memberPrincipal, Long auctionId) {
+        if (memberPrincipal.getUserRole() != UserRole.ADMIN
+                && !auctionService.isWriterOfAuction(auctionId, memberPrincipal.id()))
+            throw new AuctionException(ErrorCode.FORBIDDEN_AUCTION);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
@@ -5,9 +5,6 @@ import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
 import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
-import freshtrash.freshtrashbackend.entity.constants.UserRole;
-import freshtrash.freshtrashbackend.exception.AuctionException;
-import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.service.AuctionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -56,14 +53,7 @@ public class AuctionApi {
     @DeleteMapping("/{auctionId}")
     public ResponseEntity<Void> deleteAuction(
             @PathVariable Long auctionId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        checkIfWriterOrAdmin(memberPrincipal, auctionId);
-        auctionService.deleteAuction(auctionId);
+        auctionService.deleteAuction(auctionId, memberPrincipal.getUserRole(), memberPrincipal.id());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
-    }
-
-    private void checkIfWriterOrAdmin(MemberPrincipal memberPrincipal, Long auctionId) {
-        if (memberPrincipal.getUserRole() != UserRole.ADMIN
-                && !auctionService.isWriterOfAuction(auctionId, memberPrincipal.id()))
-            throw new AuctionException(ErrorCode.FORBIDDEN_AUCTION);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/ChatRoomApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ChatRoomApi.java
@@ -3,8 +3,6 @@ package freshtrash.freshtrashbackend.controller;
 import freshtrash.freshtrashbackend.dto.response.ChatRoomResponse;
 import freshtrash.freshtrashbackend.dto.response.ChatRoomWithMessagesResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
-import freshtrash.freshtrashbackend.exception.ChatException;
-import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -31,8 +29,8 @@ public class ChatRoomApi {
     public ResponseEntity<ChatRoomWithMessagesResponse> getChatRoomWithMessages(
             @PathVariable Long chatRoomId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
 
-        checkIfSellerOrBuyerOfChatRoom(chatRoomId, memberPrincipal.id());
-        return ResponseEntity.ok(ChatRoomWithMessagesResponse.fromEntity(chatRoomService.getChatRoom(chatRoomId)));
+        return ResponseEntity.ok(
+                ChatRoomWithMessagesResponse.fromEntity(chatRoomService.getChatRoom(chatRoomId, memberPrincipal.id())));
     }
 
     /**
@@ -42,13 +40,5 @@ public class ChatRoomApi {
     public ResponseEntity<Void> closeChatRoom(@PathVariable Long chatRoomId) {
         chatRoomService.closeChatRoom(chatRoomId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
-    }
-
-    /**
-     * 판매자 또는 구매자만이 대상 채팅방을 조회할 수 있습니다
-     */
-    private void checkIfSellerOrBuyerOfChatRoom(Long chatRoomId, Long memberId) {
-        if (!chatRoomService.isSellerOrBuyerOfChatRoom(chatRoomId, memberId))
-            throw new ChatException(ErrorCode.FORBIDDEN_CHAT_ROOM);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/ChatRoomEventApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ChatRoomEventApi.java
@@ -29,7 +29,7 @@ public class ChatRoomEventApi {
     @PostMapping("/{chatRoomId}/flag")
     public ResponseEntity<Void> flagMember(
             @PathVariable Long chatRoomId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
+        ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId, memberPrincipal.id());
         userFlagChatAlarm.sendAlarm(chatRoom, memberPrincipal.id());
         return ResponseEntity.ok(null);
     }
@@ -39,11 +39,13 @@ public class ChatRoomEventApi {
      */
     @PostMapping("/{chatRoomId}/productDeal")
     public ResponseEntity<Void> handleProductDeal(
-            @PathVariable Long chatRoomId, @RequestParam ProductEventType productEventType) {
+            @PathVariable Long chatRoomId,
+            @RequestParam ProductEventType productEventType,
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         switch (productEventType) {
-            case CANCEL_BOOKING -> cancelBookingProductAlarm.sendAlarm(chatRoomId);
-            case REQUEST_BOOKING -> requestBookingProductAlarm.sendAlarm(chatRoomId);
-            default -> completeDealProductAlarm.sendAlarm(chatRoomId);
+            case CANCEL_BOOKING -> cancelBookingProductAlarm.sendAlarm(chatRoomId, memberPrincipal.id());
+            case REQUEST_BOOKING -> requestBookingProductAlarm.sendAlarm(chatRoomId, memberPrincipal.id());
+            default -> completeDealProductAlarm.sendAlarm(chatRoomId, memberPrincipal.id());
         }
         return ResponseEntity.ok(null);
     }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/MemberApi.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.controller;
 
+import freshtrash.freshtrashbackend.dto.request.MemberRequest;
 import freshtrash.freshtrashbackend.dto.response.MemberResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.service.FileService;
@@ -7,11 +8,6 @@ import freshtrash.freshtrashbackend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import freshtrash.freshtrashbackend.dto.request.MemberRequest;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -39,18 +35,11 @@ public class MemberApi {
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @RequestPart MemberRequest memberRequest,
             @RequestPart(required = false) MultipartFile imgFile) {
-        String oldFile =
+        String oldFileName =
                 memberService.findFileNameOfMember(memberPrincipal.id()).fileName();
         MemberResponse memberResponse =
                 MemberResponse.fromEntity(memberService.updateMember(memberPrincipal, memberRequest, imgFile));
-        deleteOrNotOldFile(oldFile, memberResponse);
+        fileService.deleteOrNotOldFile(oldFileName, memberResponse.fileName());
         return ResponseEntity.ok(memberResponse);
-    }
-
-    private void deleteOrNotOldFile(String oldFile, MemberResponse memberResponse) {
-        // 파일이 수정된 경우 -> 이전 파일 삭제
-        if (StringUtils.hasText(oldFile) && !oldFile.equals(memberResponse.fileName())) {
-            fileService.deleteFileIfExists(oldFile);
-        }
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/ProductLikeApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ProductLikeApi.java
@@ -7,10 +7,7 @@ import freshtrash.freshtrashbackend.dto.response.ProductResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.ProductLike;
 import freshtrash.freshtrashbackend.entity.QProductLike;
-import freshtrash.freshtrashbackend.exception.ProductException;
-import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.service.ProductLikeService;
-import freshtrash.freshtrashbackend.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,7 +24,6 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/products")
 public class ProductLikeApi {
-    private final ProductService productService;
     private final ProductLikeService productLikeService;
 
     @GetMapping("/likes")
@@ -49,7 +45,7 @@ public class ProductLikeApi {
             @RequestParam LikeStatus likeStatus,
             @PathVariable Long productId,
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        checkIfNotWriter(memberPrincipal, productId);
+
         Boolean isLike = likeStatus == LikeStatus.LIKE;
         if (isLike) {
             productLikeService.addProductLike(memberPrincipal.id(), productId);
@@ -58,14 +54,5 @@ public class ProductLikeApi {
         }
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.of(isLike));
-    }
-
-    /**
-     * 작성자인지 확인 (작성자인 경우 관심 추가/삭제 할수 없음)
-     */
-    private void checkIfNotWriter(MemberPrincipal memberPrincipal, Long productId) {
-        if (productService.isWriterOfArticle(productId, memberPrincipal.id())) {
-            throw new ProductException(ErrorCode.OWNER_PRODUCT_CANT_LIKE);
-        }
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
@@ -1,0 +1,20 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import freshtrash.freshtrashbackend.entity.constants.AuctionStatus;
+import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
+import freshtrash.freshtrashbackend.entity.constants.ProductStatus;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record AuctionRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        @NotNull ProductCategory productCategory,
+        @NotNull ProductStatus productStatus,
+        @NotNull AuctionStatus auctionStatus,
+        @NotNull Integer minBid,
+        @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startedAt,
+        @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endedAt) {}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import freshtrash.freshtrashbackend.entity.constants.AuctionStatus;
 import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
 import freshtrash.freshtrashbackend.entity.constants.ProductStatus;
+import freshtrash.freshtrashbackend.exception.AuctionException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import java.time.LocalDateTime;
 
 public record AuctionRequest(
@@ -15,6 +18,13 @@ public record AuctionRequest(
         @NotNull ProductCategory productCategory,
         @NotNull ProductStatus productStatus,
         @NotNull AuctionStatus auctionStatus,
-        @NotNull Integer minBid,
+        @PositiveOrZero int minBid,
         @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startedAt,
-        @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endedAt) {}
+        @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endedAt) {
+
+    public AuctionRequest {
+        if (startedAt.isAfter(endedAt)) {
+            throw new AuctionException(ErrorCode.INVALID_AUCTION_TIME);
+        }
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/AuctionResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/AuctionResponse.java
@@ -19,7 +19,7 @@ public record AuctionResponse(
         ProductCategory productCategory,
         ProductStatus productStatus,
         AuctionStatus auctionStatus,
-        int min_bid,
+        int minBid,
         LocalDateTime startedAt,
         LocalDateTime endedAt,
         LocalDateTime createdAt,
@@ -43,7 +43,7 @@ public record AuctionResponse(
                 .productCategory(auction.getProductCategory())
                 .productStatus(auction.getProductStatus())
                 .auctionStatus(auction.getAuctionStatus())
-                .min_bid(auction.getMin_bid())
+                .minBid(auction.getMinBid())
                 .startedAt(auction.getStartedAt())
                 .endedAt(auction.getEndedAt())
                 .createdAt(auction.getCreatedAt())

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/AuctionResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/AuctionResponse.java
@@ -1,0 +1,53 @@
+package freshtrash.freshtrashbackend.dto.response;
+
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.constants.AuctionStatus;
+import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
+import freshtrash.freshtrashbackend.entity.constants.ProductStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record AuctionResponse(
+        Long id,
+        String title,
+        String content,
+        Integer viewCount,
+        String fileName,
+        ProductCategory productCategory,
+        ProductStatus productStatus,
+        AuctionStatus auctionStatus,
+        int min_bid,
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
+        LocalDateTime createdAt,
+        MemberResponse memberResponse) {
+
+    public static AuctionResponse fromEntity(Auction auction) {
+        return AuctionResponse.of(auction, MemberResponse.fromEntity(auction.getMember()));
+    }
+
+    public static AuctionResponse fromEntity(Auction auction, MemberPrincipal memberPrincipal) {
+        return AuctionResponse.of(auction, MemberResponse.fromPrincipal(memberPrincipal));
+    }
+
+    public static AuctionResponse of(Auction auction, MemberResponse memberResponse) {
+        return AuctionResponse.builder()
+                .id(auction.getId())
+                .title(auction.getTitle())
+                .content(auction.getContent())
+                .viewCount(auction.getViewCount())
+                .fileName(auction.getFileName())
+                .productCategory(auction.getProductCategory())
+                .productStatus(auction.getProductStatus())
+                .auctionStatus(auction.getAuctionStatus())
+                .min_bid(auction.getMin_bid())
+                .startedAt(auction.getStartedAt())
+                .endedAt(auction.getEndedAt())
+                .createdAt(auction.getCreatedAt())
+                .memberResponse(memberResponse)
+                .build();
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.entity;
 
+import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
 import freshtrash.freshtrashbackend.entity.audit.CreatedAt;
 import freshtrash.freshtrashbackend.entity.constants.AuctionStatus;
 import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
@@ -71,7 +72,6 @@ public class Auction extends CreatedAt {
     public Auction(
             String title,
             String content,
-            int viewCount,
             String fileName,
             ProductCategory productCategory,
             ProductStatus productStatus,
@@ -79,11 +79,9 @@ public class Auction extends CreatedAt {
             int min_bid,
             LocalDateTime startedAt,
             LocalDateTime endedAt,
-            Member member,
             Long memberId) {
         this.title = title;
         this.content = content;
-        this.viewCount = viewCount;
         this.fileName = fileName;
         this.productCategory = productCategory;
         this.productStatus = productStatus;
@@ -91,7 +89,21 @@ public class Auction extends CreatedAt {
         this.min_bid = min_bid;
         this.startedAt = startedAt;
         this.endedAt = endedAt;
-        this.member = member;
         this.memberId = memberId;
+    }
+
+    public static Auction fromRequest(AuctionRequest auctionRequest, String fileName, Long memberId) {
+        return Auction.builder()
+                .title(auctionRequest.title())
+                .content(auctionRequest.content())
+                .productCategory(auctionRequest.productCategory())
+                .productStatus(auctionRequest.productStatus())
+                .auctionStatus(auctionRequest.auctionStatus())
+                .min_bid(auctionRequest.minBid())
+                .startedAt(auctionRequest.startedAt())
+                .endedAt(auctionRequest.endedAt())
+                .fileName(fileName)
+                .memberId(memberId)
+                .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
@@ -52,7 +52,7 @@ public class Auction extends CreatedAt {
     private AuctionStatus auctionStatus;
 
     @Column(nullable = false)
-    private int min_bid;
+    private int minBid;
 
     @Column(nullable = false)
     private LocalDateTime startedAt;
@@ -76,7 +76,7 @@ public class Auction extends CreatedAt {
             ProductCategory productCategory,
             ProductStatus productStatus,
             AuctionStatus auctionStatus,
-            int min_bid,
+            int minBid,
             LocalDateTime startedAt,
             LocalDateTime endedAt,
             Long memberId) {
@@ -86,7 +86,7 @@ public class Auction extends CreatedAt {
         this.productCategory = productCategory;
         this.productStatus = productStatus;
         this.auctionStatus = auctionStatus;
-        this.min_bid = min_bid;
+        this.minBid = minBid;
         this.startedAt = startedAt;
         this.endedAt = endedAt;
         this.memberId = memberId;
@@ -99,7 +99,7 @@ public class Auction extends CreatedAt {
                 .productCategory(auctionRequest.productCategory())
                 .productStatus(auctionRequest.productStatus())
                 .auctionStatus(auctionRequest.auctionStatus())
-                .min_bid(auctionRequest.minBid())
+                .minBid(auctionRequest.minBid())
                 .startedAt(auctionRequest.startedAt())
                 .endedAt(auctionRequest.endedAt())
                 .fileName(fileName)

--- a/src/main/java/freshtrash/freshtrashbackend/exception/AuctionException.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/AuctionException.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.exception;
+
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuctionException extends CustomException {
+    public AuctionException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuctionException(ErrorCode errorCode, Exception causeException) {
+        super(errorCode, causeException);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -47,7 +47,11 @@ public enum ErrorCode {
     // Chat
     NOT_FOUND_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
     FORBIDDEN_CHAT_ROOM(HttpStatus.FORBIDDEN, "채팅방에 대한 권한이 없습니다."),
-    CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "판매자는 자신이 등록한 폐기물에 대해 채팅을 시작할 수 없습니다.");
+    CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "판매자는 자신이 등록한 폐기물에 대해 채팅을 시작할 수 없습니다."),
+
+    // Auction
+    NOT_FOUND_AUCTION(HttpStatus.NOT_FOUND, "경매가 존재하지 않습니다."),
+    FORBIDDEN_AUCTION(HttpStatus.FORBIDDEN, "경매에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
 
     // Auction
     NOT_FOUND_AUCTION(HttpStatus.NOT_FOUND, "경매가 존재하지 않습니다."),
-    FORBIDDEN_AUCTION(HttpStatus.FORBIDDEN, "경매에 대한 권한이 없습니다.");
+    FORBIDDEN_AUCTION(HttpStatus.FORBIDDEN, "경매에 대한 권한이 없습니다."),
+    INVALID_AUCTION_TIME(HttpStatus.BAD_REQUEST, "경매 시간이 잘못되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                         .permitAll()
                         .regexMatchers("/oauth2.*", ".*auth/signup", ".*auth/signin", ".*mail.*")
                         .hasAnyRole("ANONYMOUS")
-                        .regexMatchers(".*products", "/chat-ws", ".*auth/check-nickname.*")
+                        .regexMatchers(".*products(\\??)(.*)+", ".*auctions(\\??)(.*)+", "/chat-ws", ".*auth/check-nickname.*")
                         .permitAll()
                         .anyRequest()
                         .hasAnyRole("USER", "ADMIN"))

--- a/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/security/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                         .permitAll()
                         .regexMatchers("/oauth2.*", ".*auth/signup", ".*auth/signin", ".*mail.*")
                         .hasAnyRole("ANONYMOUS")
-                        .regexMatchers(".*products(\\??)(.*)+", ".*auctions(\\??)(.*)+", "/chat-ws", ".*auth/check-nickname.*")
+                        .regexMatchers(".*products(?:\\?.*)?", ".*auctions(?:\\?.*)?", "/chat-ws", ".*auth/check-nickname.*")
                         .permitAll()
                         .anyRequest()
                         .hasAnyRole("USER", "ADMIN"))

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
@@ -5,6 +5,7 @@ import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
 import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.exception.AuctionException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.AuctionRepository;
@@ -42,11 +43,13 @@ public class AuctionService {
                 .orElseThrow(() -> new AuctionException(ErrorCode.NOT_FOUND_AUCTION));
     }
 
-    public void deleteAuction(Long auctionId) {
+    public void deleteAuction(Long auctionId, UserRole userRole, Long memberId) {
+        checkIfWriterOrAdmin(auctionId, userRole, memberId);
         auctionRepository.deleteById(auctionId);
     }
 
-    public boolean isWriterOfAuction(Long auctionId, Long memberId) {
-        return auctionRepository.existsByIdAndMemberId(auctionId, memberId);
+    private void checkIfWriterOrAdmin(Long auctionId, UserRole userRole, Long memberId) {
+        if (userRole != UserRole.ADMIN && !auctionRepository.existsByIdAndMemberId(auctionId, memberId))
+            throw new AuctionException(ErrorCode.FORBIDDEN_AUCTION);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
@@ -1,0 +1,52 @@
+package freshtrash.freshtrashbackend.service;
+
+import com.querydsl.core.types.Predicate;
+import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
+import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.exception.AuctionException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.repository.AuctionRepository;
+import freshtrash.freshtrashbackend.utils.FileUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionService {
+    private final AuctionRepository auctionRepository;
+    private final FileService fileService;
+
+    public AuctionResponse addAuction(
+            MultipartFile imgFile, AuctionRequest auctionRequest, MemberPrincipal memberPrincipal) {
+        String savedFileName = FileUtils.generateUniqueFileName(imgFile);
+        Auction auction = Auction.fromRequest(auctionRequest, savedFileName, memberPrincipal.id());
+
+        Auction savedAuction = auctionRepository.save(auction);
+        // 이미지 파일 저장
+        fileService.uploadFile(imgFile, savedFileName);
+        return AuctionResponse.fromEntity(savedAuction, memberPrincipal);
+    }
+
+    public Page<AuctionResponse> getAuctions(Predicate predicate, Pageable pageable) {
+        return auctionRepository.findAll(predicate, pageable).map(AuctionResponse::fromEntity);
+    }
+
+    public Auction getAuction(Long auctionId) {
+        return auctionRepository
+                .findById(auctionId)
+                .orElseThrow(() -> new AuctionException(ErrorCode.NOT_FOUND_AUCTION));
+    }
+
+    public void deleteAuction(Long auctionId) {
+        auctionRepository.deleteById(auctionId);
+    }
+
+    public boolean isWriterOfAuction(Long auctionId, Long memberId) {
+        return auctionRepository.existsByIdAndMemberId(auctionId, memberId);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/FileService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/FileService.java
@@ -9,4 +9,9 @@ public interface FileService {
     void uploadFile(MultipartFile file, String fileName);
 
     void deleteFileIfExists(String fileName);
+
+    /**
+     * oldFileName -> newFileName 으로 수정되었을 경우 파일을 삭제
+     */
+    void deleteOrNotOldFile(String oldFileName, String newFileName);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/LocalFileService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/LocalFileService.java
@@ -5,6 +5,7 @@ import freshtrash.freshtrashbackend.exception.FileException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -37,6 +38,11 @@ public class LocalFileService implements FileService {
         } else {
             throw new FileException(ErrorCode.FILE_NOT_FOUND);
         }
+    }
+
+    @Override
+    public void deleteOrNotOldFile(String oldFileName, String newFileName) {
+        if (StringUtils.hasText(oldFileName) && !oldFileName.equals(newFileName)) deleteFileIfExists(oldFileName);
     }
 
     private File createFileInstance(String fileName) {

--- a/src/main/java/freshtrash/freshtrashbackend/service/ProductLikeService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ProductLikeService.java
@@ -28,6 +28,7 @@ public class ProductLikeService {
 
     @Transactional
     public void addProductLike(Long memberId, Long productId) {
+        checkIfNotWriterForLike(productId, memberId);
         if (productLikeRepository.existsByMemberIdAndProductId(memberId, productId)) {
             throw new ProductException(ErrorCode.ALREADY_EXISTS_LIKE);
         }
@@ -38,11 +39,20 @@ public class ProductLikeService {
 
     @Transactional
     public void deleteProductLike(Long memberId, Long productId) {
+        checkIfNotWriterForLike(productId, memberId);
         if (!productLikeRepository.existsByMemberIdAndProductId(memberId, productId)) {
             throw new ProductException(ErrorCode.NOT_FOUND_LIKE);
         }
 
         productLikeRepository.deleteByMemberIdAndProductId(memberId, productId);
         productRepository.updateLikeCount(productId, -1);
+    }
+
+    /**
+     * 작성자는 좋아요를 추가/삭제 할 수 없음
+     */
+    public void checkIfNotWriterForLike(Long productId, Long memberId) {
+        if (productRepository.existsByIdAndMember_Id(productId, memberId))
+            throw new ProductException(ErrorCode.OWNER_PRODUCT_CANT_LIKE);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/S3Service.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/S3Service.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -84,5 +85,10 @@ public class S3Service implements FileService {
         } catch (SdkClientException | S3Exception e) {
             throw new FileException(ErrorCode.FILE_CANT_DELETE);
         }
+    }
+
+    @Override
+    public void deleteOrNotOldFile(String oldFileName, String newFileName) {
+        if (StringUtils.hasText(oldFileName) && !oldFileName.equals(newFileName)) deleteFileIfExists(oldFileName);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/ProductAlarmTemplate.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/ProductAlarmTemplate.java
@@ -12,8 +12,8 @@ public abstract class ProductAlarmTemplate {
     protected final ProductDealService productDealService;
     protected final ProductDealProducer producer;
 
-    public void sendAlarm(Long chatRoomId) {
-        ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
+    public void sendAlarm(Long chatRoomId, Long memberId) {
+        ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId, memberId);
         update(chatRoom);
         publishEvent(chatRoom);
     }

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -3,7 +3,7 @@ spring:
   web:
     locale: ko_KR
   datasource:
-    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+    driver-class-name: org.mariadb.jdbc.Driver
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -150,7 +150,7 @@ public class Fixture {
                 .productCategory(ProductCategory.BEAUTY)
                 .productStatus(ProductStatus.GOOD)
                 .auctionStatus(AuctionStatus.CANCEL)
-                .min_bid(1000)
+                .minBid(1000)
                 .startedAt(LocalDateTime.now())
                 .endedAt(LocalDateTime.now().plusDays(1))
                 .fileName("test.png")

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -6,6 +6,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Set;
 
 public class Fixture {
@@ -69,8 +70,7 @@ public class Fixture {
     }
 
     public static Member createLoginMember() {
-        return createMember(
-                123L, "testUser@gmail.com", "pw", "testUser", LoginType.EMAIL, AccountStatus.ACTIVE);
+        return createMember(123L, "testUser@gmail.com", "pw", "testUser", LoginType.EMAIL, AccountStatus.ACTIVE);
     }
 
     public static ChatRoom createChatRoom(
@@ -141,5 +141,25 @@ public class Fixture {
                 ProductDealLog.builder().buyerId(1L).sellerId(2L).productId(3L).build();
         ReflectionTestUtils.setField(productDealLog, "product", createProduct());
         return productDealLog;
+    }
+
+    public static Auction createAuction() {
+        Auction auction = Auction.builder()
+                .title("title")
+                .content("content")
+                .productCategory(ProductCategory.BEAUTY)
+                .productStatus(ProductStatus.GOOD)
+                .auctionStatus(AuctionStatus.CANCEL)
+                .min_bid(1000)
+                .startedAt(LocalDateTime.now())
+                .endedAt(LocalDateTime.now().plusDays(1))
+                .fileName("test.png")
+                .memberId(123L)
+                .build();
+
+        ReflectionTestUtils.setField(auction, "id", 1L);
+        ReflectionTestUtils.setField(auction, "member", Fixture.createMember());
+        ReflectionTestUtils.setField(auction, "viewCount", 2);
+        return auction;
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -1,12 +1,11 @@
 package freshtrash.freshtrashbackend.Fixture;
 
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
-import freshtrash.freshtrashbackend.dto.request.MemberRequest;
-import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
-import freshtrash.freshtrashbackend.dto.request.ProductRequest;
+import freshtrash.freshtrashbackend.dto.request.*;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Address;
 import freshtrash.freshtrashbackend.entity.constants.*;
+
+import java.time.LocalDateTime;
 
 public class FixtureDto {
 
@@ -68,5 +67,16 @@ public class FixtureDto {
     public static ReviewRequest createReviewRequest(int rate) {
         return new ReviewRequest(rate);
     }
-}
 
+    public static AuctionRequest createAuctionRequest() {
+        return new AuctionRequest(
+                "title",
+                "content",
+                ProductCategory.BEAUTY,
+                ProductStatus.GOOD,
+                AuctionStatus.CANCEL,
+                1000,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1));
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AlarmApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AlarmApiTest.java
@@ -74,8 +74,7 @@ class AlarmApiTest {
         // given
         Long alarmId = 1L;
         Long memberId = 123L;
-        given(alarmService.isOwnerOfAlarm(eq(alarmId), eq(memberId))).willReturn(true);
-        willDoNothing().given(alarmService).readAlarm(eq(alarmId));
+        willDoNothing().given(alarmService).readAlarm(eq(alarmId), eq(memberId));
         // when
         mvc.perform(put("/api/v1/notis/" + alarmId)).andExpect(status().isOk());
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
@@ -1,0 +1,119 @@
+package freshtrash.freshtrashbackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.core.types.Predicate;
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.Fixture.FixtureDto;
+import freshtrash.freshtrashbackend.config.TestSecurityConfig;
+import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
+import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.AuctionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(AuctionApi.class)
+@Import(TestSecurityConfig.class)
+class AuctionApiTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuctionService auctionService;
+
+    @DisplayName("경매 추가 요청")
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void given_imageAndAuctionRequestAndLoginUser_when_addAuction_then_returnSavedAuctionData() throws Exception {
+        // given
+        Long memberId = 123L;
+        MockMultipartFile image = Fixture.createMultipartFileOfImage("image");
+        AuctionRequest auctionRequest = FixtureDto.createAuctionRequest();
+        Auction auction = Auction.fromRequest(auctionRequest, "test.png", memberId);
+        MemberPrincipal memberPrincipal = FixtureDto.createMemberPrincipal();
+        AuctionResponse auctionResponse = AuctionResponse.fromEntity(auction, memberPrincipal);
+        given(auctionService.addAuction(
+                        any(MultipartFile.class), any(AuctionRequest.class), any(MemberPrincipal.class)))
+                .willReturn(auctionResponse);
+        // when
+        mvc.perform(multipart(HttpMethod.POST, "/api/v1/auctions")
+                        .file("imgFile", image.getBytes())
+                        .file(Fixture.createMultipartFileOfJson(
+                                "auctionRequest", objectMapper.writeValueAsString(auctionRequest)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value(auctionRequest.title()))
+                .andExpect(jsonPath("$.content").value(auctionRequest.content()));
+        // then
+    }
+
+    @DisplayName("경매 목록 조회")
+    @Test
+    void given_queryParamAndPageable_when_getAuction_then_pagingAuctionData() throws Exception {
+        // given
+        AuctionResponse auctionResponse = AuctionResponse.fromEntity(Fixture.createAuction());
+        given(auctionService.getAuctions(any(Predicate.class), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(auctionResponse)));
+        // when
+        mvc.perform(get("/api/v1/auctions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.numberOfElements").value(1));
+        // then
+    }
+
+    @DisplayName("경매 단일 조회")
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void given_auctionIdAndLoginUser_when_getAuction_then_returnSingleAuctionData() throws Exception {
+        // given
+        Auction auction = Fixture.createAuction();
+        given(auctionService.getAuction(eq(auction.getId()))).willReturn(auction);
+        // when
+        mvc.perform(get("/api/v1/auctions/" + auction.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(auction.getId()));
+        // then
+    }
+
+    @DisplayName("경매 삭제 요청")
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void given_auctionIdAndLoginUser_when_loginUserIsWriterOrAdmin_then_deleteAuction() throws Exception {
+        // given
+        Long auctionId = 1L, memberId = 123L;
+        given(auctionService.isWriterOfAuction(eq(auctionId), eq(memberId))).willReturn(true);
+        willDoNothing().given(auctionService).deleteAuction(auctionId);
+        // when
+        mvc.perform(delete("/api/v1/auctions/" + auctionId)).andExpect(status().isNoContent());
+        // then
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
@@ -9,6 +9,7 @@ import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
 import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.service.AuctionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -110,8 +111,8 @@ class AuctionApiTest {
     void given_auctionIdAndLoginUser_when_loginUserIsWriterOrAdmin_then_deleteAuction() throws Exception {
         // given
         Long auctionId = 1L, memberId = 123L;
-        given(auctionService.isWriterOfAuction(eq(auctionId), eq(memberId))).willReturn(true);
-        willDoNothing().given(auctionService).deleteAuction(auctionId);
+        UserRole userRole = UserRole.USER;
+        willDoNothing().given(auctionService).deleteAuction(auctionId, userRole, memberId);
         // when
         mvc.perform(delete("/api/v1/auctions/" + auctionId)).andExpect(status().isNoContent());
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ChatRoomApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ChatRoomApiTest.java
@@ -64,9 +64,7 @@ class ChatRoomApiTest {
         Long memberId = 123L;
         Long chatRoomId = 2L;
         ChatRoom chatRoom = Fixture.createChatRoom();
-        given(chatRoomService.isSellerOrBuyerOfChatRoom(eq(chatRoomId), eq(memberId)))
-                .willReturn(true);
-        given(chatRoomService.getChatRoom(eq(chatRoomId))).willReturn(chatRoom);
+        given(chatRoomService.getChatRoom(eq(chatRoomId), eq(memberId))).willReturn(chatRoom);
         // when
         mvc.perform(get("/api/v1/chats/" + chatRoomId))
                 .andExpect(status().isOk())

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ChatRoomEventApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ChatRoomEventApiTest.java
@@ -58,8 +58,9 @@ class ChatRoomEventApiTest {
     void given_chatRoomIdAndMemberId_when_then_calledSendAlarmOfChatAlarm() throws Exception {
         // given
         Long currentMemberId = 123L, chatRoomId = 2L, productId = 1L, targetMemberId = 321L;
-        ChatRoom chatRoom = Fixture.createChatRoom(productId, targetMemberId, currentMemberId, true, SellStatus.ONGOING);
-        given(chatRoomService.getChatRoom(eq(chatRoomId))).willReturn(chatRoom);
+        ChatRoom chatRoom =
+                Fixture.createChatRoom(productId, targetMemberId, currentMemberId, true, SellStatus.ONGOING);
+        given(chatRoomService.getChatRoom(eq(chatRoomId), eq(currentMemberId))).willReturn(chatRoom);
         willDoNothing().given(userFlagChatAlarm).sendAlarm(eq(chatRoom), eq(currentMemberId));
         // when
         mvc.perform(post("/api/v1/chats/" + chatRoomId + "/flag")).andExpect(status().isOk());
@@ -73,15 +74,15 @@ class ChatRoomEventApiTest {
     void given_chatRoomIdAndEventType_when_then_calledSendAlarmOfProductAlarm(ProductEventType productEventType)
             throws Exception {
         // given
-        Long chatRoomId = 2L;
+        Long chatRoomId = 2L, memberId = 123L;
         switch (productEventType) {
             case CANCEL_BOOKING -> willDoNothing()
                     .given(cancelBookingProductAlarm)
-                    .sendAlarm(eq(chatRoomId));
+                    .sendAlarm(eq(chatRoomId), eq(memberId));
             case REQUEST_BOOKING -> willDoNothing()
                     .given(requestBookingProductAlarm)
-                    .sendAlarm(eq(chatRoomId));
-            default -> willDoNothing().given(completeDealProductAlarm).sendAlarm(chatRoomId);
+                    .sendAlarm(eq(chatRoomId), eq(memberId));
+            default -> willDoNothing().given(completeDealProductAlarm).sendAlarm(chatRoomId, memberId);
         }
         // when
         mvc.perform(post("/api/v1/chats/" + chatRoomId + "/productDeal")

--- a/src/test/java/freshtrash/freshtrashbackend/controller/MemberApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/MemberApiTest.java
@@ -23,8 +23,7 @@ import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.security.test.context.support.TestExecutionEvent.TEST_EXECUTION;
@@ -91,7 +90,7 @@ class MemberApiTest {
         given(memberService.updateMember(
                         any(MemberPrincipal.class), any(MemberRequest.class), any(MultipartFile.class)))
                 .willReturn(member);
-        willDoNothing().given(localFileService).deleteFileIfExists(eq(oldFile));
+        willDoNothing().given(localFileService).deleteOrNotOldFile(eq(oldFile), anyString());
         // when
         mvc.perform(multipart(HttpMethod.PUT, "/api/v1/members")
                         .file("imgFile", imgFile.getBytes())

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ProductApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ProductApiTest.java
@@ -11,9 +11,9 @@ import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Address;
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.entity.Product;
+import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
 import freshtrash.freshtrashbackend.entity.constants.ProductStatus;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
-import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import freshtrash.freshtrashbackend.service.ChatRoomService;
 import freshtrash.freshtrashbackend.service.LocalFileService;
@@ -85,9 +85,10 @@ class ProductApiTest {
                 .andExpect(jsonPath("$.viewCount").value(product.getViewCount()))
                 .andExpect(jsonPath("$.productCategory")
                         .value(product.getProductCategory().name()))
+                .andExpect(jsonPath("$.productStatus")
+                        .value(product.getProductStatus().name()))
                 .andExpect(
-                        jsonPath("$.productStatus").value(product.getProductStatus().name()))
-                .andExpect(jsonPath("$.sellStatus").value(product.getSellStatus().name()));
+                        jsonPath("$.sellStatus").value(product.getSellStatus().name()));
         // then
     }
 
@@ -116,13 +117,14 @@ class ProductApiTest {
         Product product = Product.fromRequest(productRequest, imgFile.getOriginalFilename(), memberId);
         ReflectionTestUtils.setField(product, "member", Fixture.createMember());
         ProductResponse productResponse = ProductResponse.fromEntity(product);
-        given(productService.addProduct(any(MultipartFile.class), any(ProductRequest.class), any(MemberPrincipal.class)))
+        given(productService.addProduct(
+                        any(MultipartFile.class), any(ProductRequest.class), any(MemberPrincipal.class)))
                 .willReturn(productResponse);
         // when
         mvc.perform(multipart(HttpMethod.POST, "/api/v1/products")
                         .file("imgFile", imgFile.getBytes())
-                        .file(new MockMultipartFile(
-                                "productRequest", "", "application/json", objectMapper.writeValueAsBytes(productRequest)))
+                        .file(Fixture.createMultipartFileOfJson(
+                                "productRequest", objectMapper.writeValueAsString(productRequest)))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.title").value(productRequest.title()))
@@ -133,8 +135,8 @@ class ProductApiTest {
                         .value(productRequest.productCategory().name()))
                 .andExpect(jsonPath("$.productStatus")
                         .value(productRequest.productStatus().name()))
-                .andExpect(
-                        jsonPath("$.sellStatus").value(productRequest.sellStatus().name()));
+                .andExpect(jsonPath("$.sellStatus")
+                        .value(productRequest.sellStatus().name()));
         // then
     }
 
@@ -184,7 +186,10 @@ class ProductApiTest {
         mvc.perform(multipart(HttpMethod.POST, "/api/v1/products")
                         .file("imgFile", imgFile.getBytes())
                         .file(new MockMultipartFile(
-                                "productRequest", "", "application/json", objectMapper.writeValueAsBytes(productRequest)))
+                                "productRequest",
+                                "",
+                                "application/json",
+                                objectMapper.writeValueAsBytes(productRequest)))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
         // then
@@ -213,7 +218,10 @@ class ProductApiTest {
         mvc.perform(multipart(HttpMethod.PUT, "/api/v1/products/" + productId)
                         .file("imgFile", imgFile.getBytes())
                         .file(new MockMultipartFile(
-                                "productRequest", "", "application/json", objectMapper.writeValueAsBytes(productRequest)))
+                                "productRequest",
+                                "",
+                                "application/json",
+                                objectMapper.writeValueAsBytes(productRequest)))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value(productRequest.title()))
@@ -224,8 +232,8 @@ class ProductApiTest {
                         .value(productRequest.productCategory().name()))
                 .andExpect(jsonPath("$.productStatus")
                         .value(productRequest.productStatus().name()))
-                .andExpect(
-                        jsonPath("$.sellStatus").value(productRequest.sellStatus().name()));
+                .andExpect(jsonPath("$.sellStatus")
+                        .value(productRequest.sellStatus().name()));
         // then
     }
 
@@ -265,7 +273,8 @@ class ProductApiTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.productTitle").value(product.getTitle()))
                 .andExpect(jsonPath("$.sellStatus").value("ONGOING"))
-                .andExpect(jsonPath("$.sellerNickname").value(product.getMember().getNickname()))
+                .andExpect(
+                        jsonPath("$.sellerNickname").value(product.getMember().getNickname()))
                 .andExpect(jsonPath("$.buyerNickname").value(buyerNickname));
         // then
     }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ProductApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ProductApiTest.java
@@ -14,6 +14,7 @@ import freshtrash.freshtrashbackend.entity.Product;
 import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
 import freshtrash.freshtrashbackend.entity.constants.ProductStatus;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import freshtrash.freshtrashbackend.service.ChatRoomService;
 import freshtrash.freshtrashbackend.service.LocalFileService;
@@ -208,7 +209,6 @@ class ProductApiTest {
         Product product = Product.fromRequest(productRequest, imgFile.getOriginalFilename(), memberId);
         ReflectionTestUtils.setField(product, "member", Fixture.createMember());
         ProductResponse productResponse = ProductResponse.fromEntity(product);
-        given(productService.isWriterOfArticle(eq(productId), eq(memberId))).willReturn(true);
         given(productService.findFileNameOfProduct(eq(productId))).willReturn(new FileNameSummary(fileName));
         given(productService.updateProduct(
                         eq(productId), any(MultipartFile.class), any(ProductRequest.class), any(MemberPrincipal.class)))
@@ -242,13 +242,12 @@ class ProductApiTest {
     @WithUserDetails(value = "testUser@gmail.com", setupBefore = TEST_EXECUTION)
     void given_productIdAndWriter_when_then_deleteProductAndFile() throws Exception {
         // given
-        Long productId = 1L;
-        Long memberId = 123L;
+        Long productId = 1L, memberId = 123L;
+        UserRole userRole = UserRole.USER;
         String fileName = "test.png";
-        given(productService.isWriterOfArticle(eq(productId), eq(memberId))).willReturn(true);
         given(productService.findFileNameOfProduct(eq(productId))).willReturn(new FileNameSummary(fileName));
         willDoNothing().given(localFileService).deleteFileIfExists(eq(fileName));
-        willDoNothing().given(productService).deleteProduct(eq(productId));
+        willDoNothing().given(productService).deleteProduct(eq(productId), eq(userRole), eq(memberId));
         // when
         mvc.perform(delete("/api/v1/products/" + productId)).andExpect(status().isNoContent());
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ProductLikeApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ProductLikeApiTest.java
@@ -46,9 +46,6 @@ class ProductLikeApiTest {
     @MockBean
     private ProductLikeService productLikeService;
 
-    @MockBean
-    private ProductService productService;
-
     @Test
     @DisplayName("관심 폐기물 목록 조회")
     @WithUserDetails(value = "testUser@gmail.com", setupBefore = TEST_EXECUTION)
@@ -73,8 +70,11 @@ class ProductLikeApiTest {
         // given
         Long productId = 1L;
         Long memberId = 123L;
-        willDoNothing().given(productLikeService).addProductLike(memberId, productId);
-        willDoNothing().given(productLikeService).deleteProductLike(memberId, productId);
+        if (likeStatus == LikeStatus.LIKE) {
+            willDoNothing().given(productLikeService).addProductLike(memberId, productId);
+        } else {
+            willDoNothing().given(productLikeService).deleteProductLike(memberId, productId);
+        }
         // when
         mvc.perform(post("/api/v1/products/" + productId + "/likes").queryParam("likeStatus", String.valueOf(likeStatus)))
                 .andExpect(status().isOk())

--- a/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
@@ -63,10 +63,11 @@ class AlarmServiceTest {
     @DisplayName("알람 읽음 처리")
     void given_alarmId_when_readAlarm_then_updateReadAtToNow() {
         // given
-        Long alarmId = 1L;
+        Long alarmId = 1L, memberId = 123L;
+        given(alarmRepository.existsByIdAndMember_Id(eq(alarmId), eq(memberId))).willReturn(true);
         willDoNothing().given(alarmRepository).updateReadAtById(eq(alarmId));
         // when
-        alarmService.readAlarm(alarmId);
+        alarmService.readAlarm(alarmId, memberId);
         // then
         then(alarmRepository).should(times(1)).updateReadAtById(anyLong());
     }

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
@@ -61,7 +61,7 @@ class AuctionServiceTest {
         assertThat(auctionResponse.productCategory()).isEqualTo(auctionRequest.productCategory());
         assertThat(auctionResponse.productStatus()).isEqualTo(auctionRequest.productStatus());
         assertThat(auctionResponse.auctionStatus()).isEqualTo(auctionRequest.auctionStatus());
-        assertThat(auctionResponse.min_bid()).isEqualTo(auctionRequest.min_bid());
+        assertThat(auctionResponse.minBid()).isEqualTo(auctionRequest.minBid());
         assertThat(auctionResponse.startedAt()).isEqualTo(auctionRequest.startedAt());
         assertThat(auctionResponse.endedAt()).isEqualTo(auctionRequest.endedAt());
     }

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
@@ -1,0 +1,106 @@
+package freshtrash.freshtrashbackend.service;
+
+import com.querydsl.core.types.Predicate;
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.Fixture.FixtureDto;
+import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
+import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.QAuction;
+import freshtrash.freshtrashbackend.repository.AuctionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class AuctionServiceTest {
+    @InjectMocks
+    private AuctionService auctionService;
+
+    @Mock
+    private AuctionRepository auctionRepository;
+
+    @Mock
+    private LocalFileService fileService;
+
+    @DisplayName("경매 추가")
+    @Test
+    void given_imageAndAuctionRequestData_when_addAuction_then_returnSavedAuctionData() {
+        // given
+        AuctionRequest auctionRequest = FixtureDto.createAuctionRequest();
+        MemberPrincipal memberPrincipal = FixtureDto.createMemberPrincipal();
+        MockMultipartFile image = Fixture.createMultipartFileOfImage("image");
+        String fileName = "test.png";
+        Auction auction = Auction.fromRequest(auctionRequest, fileName, memberPrincipal.id());
+        given(auctionRepository.save(any(Auction.class))).willReturn(auction);
+        willDoNothing().given(fileService).uploadFile(eq(image), anyString());
+        // when
+        AuctionResponse auctionResponse = auctionService.addAuction(image, auctionRequest, memberPrincipal);
+        // then
+        assertThat(auctionResponse.title()).isEqualTo(auctionRequest.title());
+        assertThat(auctionResponse.content()).isEqualTo(auctionRequest.content());
+        assertThat(auctionResponse.productCategory()).isEqualTo(auctionRequest.productCategory());
+        assertThat(auctionResponse.productStatus()).isEqualTo(auctionRequest.productStatus());
+        assertThat(auctionResponse.auctionStatus()).isEqualTo(auctionRequest.auctionStatus());
+        assertThat(auctionResponse.min_bid()).isEqualTo(auctionRequest.min_bid());
+        assertThat(auctionResponse.startedAt()).isEqualTo(auctionRequest.startedAt());
+        assertThat(auctionResponse.endedAt()).isEqualTo(auctionRequest.endedAt());
+    }
+
+    @DisplayName("경매 목록 조회")
+    @Test
+    void given_queryParamAndPageable_when_getAuction_then_pagingAuctionData() {
+        // given
+        int expectedSize = 1;
+        Predicate predicate = QAuction.auction.title.equalsIgnoreCase("title");
+        Pageable pageable = PageRequest.of(0, 6);
+        given(auctionRepository.findAll(eq(predicate), eq(pageable)))
+                .willReturn(new PageImpl<>(List.of(Fixture.createAuction())));
+        // when
+        Page<AuctionResponse> auctions = auctionService.getAuctions(predicate, pageable);
+        // then
+        assertThat(auctions.getTotalElements()).isEqualTo(expectedSize);
+    }
+
+    @DisplayName("경매 단일 조회")
+    @Test
+    void given_auctionId_when_getAuction_then_returnSingleAuction() {
+        // given
+        Auction expectedAuction = Fixture.createAuction();
+        given(auctionRepository.findById(eq(expectedAuction.getId()))).willReturn(Optional.of(expectedAuction));
+        // when
+        Auction auction = auctionService.getAuction(expectedAuction.getId());
+        // then
+        assertThat(auction.getId()).isEqualTo(expectedAuction.getId());
+    }
+
+    @DisplayName("경매 삭제")
+    @Test
+    void given_auctionId_when_then_deleteAuction() {
+        //given
+        Long auctionId = 1L;
+        willDoNothing().given(auctionRepository).deleteById(auctionId);
+        //when
+        auctionService.deleteAuction(auctionId);
+        //then
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
@@ -8,6 +8,7 @@ import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.entity.QAuction;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.repository.AuctionRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -96,11 +97,13 @@ class AuctionServiceTest {
     @DisplayName("경매 삭제")
     @Test
     void given_auctionId_when_then_deleteAuction() {
-        //given
-        Long auctionId = 1L;
+        // given
+        Long auctionId = 1L, memberId = 123L;
+        UserRole userRole = UserRole.USER;
+        given(auctionRepository.existsByIdAndMemberId(eq(auctionId), eq(memberId))).willReturn(true);
         willDoNothing().given(auctionRepository).deleteById(auctionId);
-        //when
-        auctionService.deleteAuction(auctionId);
-        //then
+        // when
+        auctionService.deleteAuction(auctionId, userRole, memberId);
+        // then
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/service/ChatRoomServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/ChatRoomServiceTest.java
@@ -66,10 +66,12 @@ class ChatRoomServiceTest {
     @DisplayName("채팅방 단일 조회")
     void given_chatRoomId_when_getChatRoom_then_returnChatRoom() {
         // given
-        Long chatRoomId = 1L;
+        Long chatRoomId = 1L, memberId = 123L;
+        given(chatRoomRepository.existsByIdAndMemberId(eq(chatRoomId), eq(memberId)))
+                .willReturn(true);
         given(chatRoomRepository.findById(eq(chatRoomId))).willReturn(Optional.of(Fixture.createChatRoom()));
         // when
-        ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
+        ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId, memberId);
         // then
         assertThat(chatRoom).isNotNull();
     }

--- a/src/test/java/freshtrash/freshtrashbackend/service/ProductLikeServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/ProductLikeServiceTest.java
@@ -45,8 +45,10 @@ class ProductLikeServiceTest {
         Long memberId = 1L;
         ProductCategory category = ProductCategory.BEAUTY;
         int expectedSize = 1;
-        Predicate predicate =
-                QProductLike.productLike.memberId.eq(memberId).and(QProductLike.productLike.product.productCategory.eq(category));
+        Predicate predicate = QProductLike.productLike
+                .memberId
+                .eq(memberId)
+                .and(QProductLike.productLike.product.productCategory.eq(category));
         Pageable pageable = PageRequest.of(0, 6, Sort.Direction.DESC, "createdAt");
         given(productLikeRepository.findAll(eq(predicate), eq(pageable)))
                 .willReturn(new PageImpl<>(List.of(Fixture.createProductLike())));
@@ -60,12 +62,14 @@ class ProductLikeServiceTest {
     @DisplayName("관심 폐기물 추가")
     void given_memberIdAndProductId_when_addProductLike_then_saveProductLikeAndUpdateLikeCount() {
         // given
-        Long memberId = 123L;
-        Long productId = 1L;
+        Long memberId = 123L, productId = 1L;
         ProductLike productLike = ProductLike.of(memberId, productId);
+        given(productRepository.existsByIdAndMember_Id(eq(productId), eq(memberId)))
+                .willReturn(false);
+        given(productLikeRepository.existsByMemberIdAndProductId(memberId, productId))
+                .willReturn(false);
         given(productLikeRepository.save(any(ProductLike.class))).willReturn(productLike);
         willDoNothing().given(productRepository).updateLikeCount(productId, 1);
-
         // when
         productLikeService.addProductLike(memberId, productId);
         // then
@@ -75,12 +79,13 @@ class ProductLikeServiceTest {
     @DisplayName("관심 폐기물 삭제")
     void given_memberIdAndProductId_when_deleteProductLike_then_deleteProductLikeAndUpdateLikeCount() {
         // given
-        Long memberId = 123L;
-        Long productId = 1L;
-        given(productLikeRepository.existsByMemberIdAndProductId(memberId, productId)).willReturn(true);
+        Long memberId = 123L, productId = 1L;
+        given(productRepository.existsByIdAndMember_Id(eq(productId), eq(memberId)))
+                .willReturn(false);
+        given(productLikeRepository.existsByMemberIdAndProductId(memberId, productId))
+                .willReturn(true);
         willDoNothing().given(productLikeRepository).deleteByMemberIdAndProductId(memberId, productId);
         willDoNothing().given(productRepository).updateLikeCount(productId, -1);
-
         // when
         productLikeService.deleteProductLike(memberId, productId);
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/service/ProductServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/ProductServiceTest.java
@@ -8,6 +8,7 @@ import freshtrash.freshtrashbackend.dto.response.ProductResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Product;
 import freshtrash.freshtrashbackend.entity.QProduct;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.repository.ProductRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -102,10 +103,13 @@ class ProductServiceTest {
         String updatedFileName = "updated.png";
         MemberPrincipal memberPrincipal = FixtureDto.createMemberPrincipal();
         Product product = Product.fromRequest(productRequest, updatedFileName, memberPrincipal.id());
+        given(productRepository.existsByIdAndMember_Id(eq(productId), eq(memberPrincipal.id())))
+                .willReturn(true);
         given(productRepository.save(any(Product.class))).willReturn(product);
         willDoNothing().given(fileService).uploadFile(any(MultipartFile.class), anyString());
         // when
-        ProductResponse productResponse = productService.updateProduct(productId, multipartFile, productRequest, memberPrincipal);
+        ProductResponse productResponse =
+                productService.updateProduct(productId, multipartFile, productRequest, memberPrincipal);
 
         // then
         assertThat(productResponse.title()).isEqualTo(productRequest.title());
@@ -122,10 +126,13 @@ class ProductServiceTest {
     @DisplayName("Product 삭제")
     void given_productId_when_then_deleteProductAndFile() {
         // given
-        Long productId = 1L;
+        Long productId = 1L, memberId = 123L;
+        UserRole userRole = UserRole.USER;
+        given(productRepository.existsByIdAndMember_Id(eq(productId), eq(memberId)))
+                .willReturn(true);
         willDoNothing().given(productRepository).deleteById(eq(productId));
         // when
-        productService.deleteProduct(productId);
+        productService.deleteProduct(productId, userRole, memberId);
         // then
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 경매 글에 대한 추가/삭제/조회 기능을 구현합니다. 수정은 할 수 없으므로 수정 기능은 추가하지 않습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- 겅매 등록 기능
  - 시작/마감 일시 데이터는 yyyy-MM-dd HH:mm:ss 형식으로 요청받도록 반영했습니다.

    <img width="1333" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/2905134c-2399-4a13-b42e-697a14fff37e">
    <img width="253" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/77fd1bef-8f36-4970-82a4-6c7738cff36d">

- 경매 조회 기능
  - 목록 조회
    - 카테고리, 제목 검색 기능도 반영되었습니다.
    
      <img width="1333" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/b756eaf7-d3dc-40a1-b946-1962ff007e4c">

  - 단일 조회

      <img width="1333" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/c9a5fe7f-8df8-42b5-85bb-1f2a31e0b46b">

- 경매 삭제 기능

  <img width="1333" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/13a3c718-e6ef-4a07-8a6c-a08c48afaf4c">


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 중고 상품/경매 목록 조회 시 쿼리 파라미터 포함하는 경우 401 에러 문제
  - SecurityConfig의 regex를 수정하여 쿼리 파라미터가 추가되었을 경우도 matching할 수 있도록 적용

- log 확인을 위해 설정한 driver를 mariadb driver로 다시 변경

- 각 API의 방어로직을 Service 레이어로 이동
    - 방어로직의 경우 API에 있는 것보다 Service 클래스에 속해있는 것이 좀 더 단일 책임 원칙(SRP)에 준수한다고 판단했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #159 
