### PR TITLE
경매 입찰 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-inline'

--- a/database/mariadb/initdb.d/create_table.sql
+++ b/database/mariadb/initdb.d/create_table.sql
@@ -144,12 +144,27 @@ CREATE TABLE `auctions`
     `product_category` varchar(255)          NOT NULL,
     `product_status`   varchar(255)          NOT NULL,
     `auction_status`   varchar(255)          NOT NULL,
-    `min_bid`          integer               NOT NULL,
+    `final_bid`          integer               NOT NULL,
     `view_count`       integer               NOT NULL,
     `started_at`       datetime              NOT NULL,
     `ended_at`         datetime              NOT NULL,
     `created_at`       datetime              NOT NULL,
+    `version`          integer default 0     NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='경매';
+
+CREATE TABLE `bidding_history`
+(
+    `id` bigint AUTO_INCREMENT NOT NULL ,
+    `member_id` bigint NOT NULL ,
+    `auction_id` bigint NOT NULL ,
+    `price` integer NOT NULL ,
+    `is_success_bidding` tinyint(1) NOT NULL ,
+    `created_at` datetime NOT NULL ,
+    PRIMARY KEY (`id`),
+    foreign key (`member_id`) references members (id) on delete cascade,
+    foreign key (`auction_id`) references auctions (id) on delete cascade
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='입찰 내역';

--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -176,7 +176,12 @@ values (1, 'CHAT', json_object('fromMemberId', 2, 'targetId', 1), '거래 완료
        (5, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), 'abc님이 판매중으로 변경하였습니다.', now(), null, null),
        (1, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), 'abc님이 판매중으로 변경하였습니다.', now(), null, now());
 
-insert into auctions(member_id, file_name, title, content, product_category, product_status, auction_status, min_bid, view_count, started_at, ended_at, created_at) values
+insert into auctions(member_id, file_name, title, content, product_category, product_status, auction_status, final_bid, view_count, started_at, ended_at, created_at) values
 (1, 'test.png', 'title', 'content', 'CLOTHING', 'GOOD', 'ONGOING', 1000, 1, now(), date_add(now(), interval 1 hour), now()),
 (2, 'test.png', 'title2', 'content2', 'HEALTH', 'GOOD', 'ONGOING', 1000, 3, now(), date_add(now(), interval 1 hour), now()),
 (3, 'test.png', 'title3', 'content3', 'SPORTS', 'GOOD', 'CLOSE', 3000, 5, now(), date_add(now(), interval 1 hour), now());
+
+insert into bidding_history(member_id, auction_id, price, is_success_bidding, created_at) values
+(2, 1, 1000, true, now()),
+(1, 2, 1000, false, now()),
+(1, 3, 3000, true, now());

--- a/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
+++ b/src/main/java/freshtrash/freshtrashbackend/FreshTrashBackendApplication.java
@@ -3,11 +3,13 @@ package freshtrash.freshtrashbackend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@ConfigurationPropertiesScan
-@SpringBootApplication
+@EnableRetry
 @EnableScheduling
+@SpringBootApplication
+@ConfigurationPropertiesScan
 public class FreshTrashBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
@@ -2,6 +2,7 @@ package freshtrash.freshtrashbackend.controller;
 
 import com.querydsl.core.types.Predicate;
 import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
+import freshtrash.freshtrashbackend.dto.request.BiddingRequest;
 import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
@@ -55,5 +56,14 @@ public class AuctionApi {
             @PathVariable Long auctionId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         auctionService.deleteAuction(auctionId, memberPrincipal.getUserRole(), memberPrincipal.id());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+    }
+
+    @PutMapping("/{auctionId}")
+    public ResponseEntity<Void> requestBidding(
+            @PathVariable Long auctionId,
+            @RequestBody @Valid BiddingRequest biddingRequest,
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        auctionService.requestBidding(auctionId, biddingRequest.biddingPrice(), memberPrincipal.id());
+        return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
@@ -58,8 +58,8 @@ public class AuctionApi {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 
-    @PutMapping("/{auctionId}")
-    public ResponseEntity<Void> requestBidding(
+    @PutMapping("/{auctionId}/bid")
+    public ResponseEntity<Void> placeBidding(
             @PathVariable Long auctionId,
             @RequestBody @Valid BiddingRequest biddingRequest,
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
@@ -18,7 +18,7 @@ public record AuctionRequest(
         @NotNull ProductCategory productCategory,
         @NotNull ProductStatus productStatus,
         @NotNull AuctionStatus auctionStatus,
-        @PositiveOrZero int finalBid,
+        @PositiveOrZero int minimumBid,
         @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startedAt,
         @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endedAt) {
 

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionRequest.java
@@ -18,7 +18,7 @@ public record AuctionRequest(
         @NotNull ProductCategory productCategory,
         @NotNull ProductStatus productStatus,
         @NotNull AuctionStatus auctionStatus,
-        @PositiveOrZero int minBid,
+        @PositiveOrZero int finalBid,
         @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startedAt,
         @NotNull @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endedAt) {
 

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/BiddingRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/BiddingRequest.java
@@ -1,0 +1,6 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+public record BiddingRequest(@NotNull @PositiveOrZero Integer biddingPrice) {}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/AuctionResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/AuctionResponse.java
@@ -19,7 +19,7 @@ public record AuctionResponse(
         ProductCategory productCategory,
         ProductStatus productStatus,
         AuctionStatus auctionStatus,
-        int minBid,
+        int finalBid,
         LocalDateTime startedAt,
         LocalDateTime endedAt,
         LocalDateTime createdAt,
@@ -43,7 +43,7 @@ public record AuctionResponse(
                 .productCategory(auction.getProductCategory())
                 .productStatus(auction.getProductStatus())
                 .auctionStatus(auction.getAuctionStatus())
-                .minBid(auction.getMinBid())
+                .finalBid(auction.getFinalBid())
                 .startedAt(auction.getStartedAt())
                 .endedAt(auction.getEndedAt())
                 .createdAt(auction.getCreatedAt())

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
@@ -103,7 +103,7 @@ public class Auction extends CreatedAt {
                 .productCategory(auctionRequest.productCategory())
                 .productStatus(auctionRequest.productStatus())
                 .auctionStatus(auctionRequest.auctionStatus())
-                .finalBid(auctionRequest.finalBid())
+                .finalBid(auctionRequest.minimumBid())
                 .startedAt(auctionRequest.startedAt())
                 .endedAt(auctionRequest.endedAt())
                 .fileName(fileName)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
@@ -51,8 +51,9 @@ public class Auction extends CreatedAt {
     @Enumerated(value = EnumType.STRING)
     private AuctionStatus auctionStatus;
 
+    @Setter
     @Column(nullable = false)
-    private int minBid;
+    private int finalBid; // 최종 입찰 금액
 
     @Column(nullable = false)
     private LocalDateTime startedAt;
@@ -68,6 +69,9 @@ public class Auction extends CreatedAt {
     @Column(nullable = false)
     private Long memberId;
 
+    @Version
+    private int version;
+
     @Builder
     public Auction(
             String title,
@@ -76,7 +80,7 @@ public class Auction extends CreatedAt {
             ProductCategory productCategory,
             ProductStatus productStatus,
             AuctionStatus auctionStatus,
-            int minBid,
+            int finalBid,
             LocalDateTime startedAt,
             LocalDateTime endedAt,
             Long memberId) {
@@ -86,7 +90,7 @@ public class Auction extends CreatedAt {
         this.productCategory = productCategory;
         this.productStatus = productStatus;
         this.auctionStatus = auctionStatus;
-        this.minBid = minBid;
+        this.finalBid = finalBid;
         this.startedAt = startedAt;
         this.endedAt = endedAt;
         this.memberId = memberId;
@@ -99,7 +103,7 @@ public class Auction extends CreatedAt {
                 .productCategory(auctionRequest.productCategory())
                 .productStatus(auctionRequest.productStatus())
                 .auctionStatus(auctionRequest.auctionStatus())
-                .minBid(auctionRequest.minBid())
+                .finalBid(auctionRequest.finalBid())
                 .startedAt(auctionRequest.startedAt())
                 .endedAt(auctionRequest.endedAt())
                 .fileName(fileName)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
@@ -1,0 +1,50 @@
+package freshtrash.freshtrashbackend.entity;
+
+import freshtrash.freshtrashbackend.entity.audit.CreatedAt;
+import lombok.*;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Getter
+@Entity
+@ToString(callSuper = true)
+@Table(name = "bidding_history")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BiddingHistory extends CreatedAt {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(nullable = false)
+    private int price; // 입찰 금액
+
+    @Column(nullable = false)
+    private boolean isSuccessBidding; // 낙찰 여부
+
+    @ToString.Exclude
+    @ManyToOne(optional = false, fetch = LAZY)
+    @JoinColumn(name = "memberId", insertable = false, updatable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @ToString.Exclude
+    @ManyToOne(optional = false, fetch = LAZY)
+    @JoinColumn(name = "auctionId", insertable = false, updatable = false)
+    private Auction auction;
+
+    @Column(nullable = false)
+    private Long auctionId;
+
+    @Builder
+    public BiddingHistory(int price, Long memberId, Long auctionId) {
+        this.price = price;
+        this.memberId = memberId;
+        this.auctionId = auctionId;
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,6 +29,14 @@ public class GlobalExceptionHandler {
         log.error("MethodArgumentNotValidException is occurred.", e);
         String message = "Validation failed for argument in "
                 + e.getParameter().getExecutable().getName();
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(ExceptionResponse.fromBindingResult(message, e.getBindingResult()));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ExceptionResponse> resolveException(BindException e) {
+        log.error("BindException is occurred.", e);
+        String message = "Validation failed for argument in " + e.getObjectName();
         return ResponseEntity.status(BAD_REQUEST)
                 .body(ExceptionResponse.fromBindingResult(message, e.getBindingResult()));
     }

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -52,7 +52,10 @@ public enum ErrorCode {
     // Auction
     NOT_FOUND_AUCTION(HttpStatus.NOT_FOUND, "경매가 존재하지 않습니다."),
     FORBIDDEN_AUCTION(HttpStatus.FORBIDDEN, "경매에 대한 권한이 없습니다."),
-    INVALID_AUCTION_TIME(HttpStatus.BAD_REQUEST, "경매 시간이 잘못되었습니다.");
+    INVALID_AUCTION_TIME(HttpStatus.BAD_REQUEST, "경매 시간이 잘못되었습니다."),
+    WRITER_CANT_BIDDING(HttpStatus.BAD_REQUEST, "경매 등록 사용자는 입찰할 수 없습니다."),
+    INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "요청 입찰가는 기존 입찰가보다 커야합니다."),
+    CANT_BIDDING_TIME(HttpStatus.BAD_REQUEST, "지금은 경매 중이 아닙니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
@@ -1,0 +1,9 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(propagation = Propagation.SUPPORTS)
+public interface BiddingHistoryRepository extends JpaRepository<BiddingHistory, Long> {}

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
@@ -5,20 +5,33 @@ import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
 import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.exception.AuctionException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.AuctionRepository;
+import freshtrash.freshtrashbackend.repository.BiddingHistoryRepository;
 import freshtrash.freshtrashbackend.utils.FileUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.LockModeType;
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class AuctionService {
+    private final BiddingHistoryRepository biddingHistoryRepository;
     private final AuctionRepository auctionRepository;
     private final FileService fileService;
 
@@ -48,8 +61,37 @@ public class AuctionService {
         auctionRepository.deleteById(auctionId);
     }
 
+    @Transactional
+    @Lock(LockModeType.OPTIMISTIC)
+    @Retryable(
+            value = {ObjectOptimisticLockingFailureException.class, CannotAcquireLockException.class},
+            backoff = @Backoff(delay = 1000, maxDelay = 5000))
+    public void requestBidding(Long auctionId, int biddingPrice, Long memberId) {
+        Auction auction = getAuction(auctionId);
+        // 요청한 입찰가는 이전 입찰가보다 높아야함
+        if (auction.getFinalBid() >= biddingPrice) throw new AuctionException(ErrorCode.INVALID_BIDDING_PRICE);
+        // 경매를 올린 사용자는 입찰이 불가능
+        if (Objects.equals(auction.getMemberId(), memberId)) throw new AuctionException(ErrorCode.WRITER_CANT_BIDDING);
+        // 경매가 시작하기 전 또는 후에는 입찰이 불가능
+        if (LocalDateTime.now().isBefore(auction.getStartedAt())
+                && LocalDateTime.now().isAfter(auction.getEndedAt()))
+            throw new AuctionException(ErrorCode.CANT_BIDDING_TIME);
+        // 입찰가 변경
+        auction.setFinalBid(biddingPrice);
+        // 입찰 기록
+        addBiddingHistory(auctionId, memberId, biddingPrice);
+    }
+
     private void checkIfWriterOrAdmin(Long auctionId, UserRole userRole, Long memberId) {
         if (userRole != UserRole.ADMIN && !auctionRepository.existsByIdAndMemberId(auctionId, memberId))
             throw new AuctionException(ErrorCode.FORBIDDEN_AUCTION);
+    }
+
+    private void addBiddingHistory(Long auctionId, Long memberId, int price) {
+        biddingHistoryRepository.save(BiddingHistory.builder()
+                .auctionId(auctionId)
+                .memberId(memberId)
+                .price(price)
+                .build());
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/Fixture.java
@@ -150,7 +150,7 @@ public class Fixture {
                 .productCategory(ProductCategory.BEAUTY)
                 .productStatus(ProductStatus.GOOD)
                 .auctionStatus(AuctionStatus.CANCEL)
-                .minBid(1000)
+                .finalBid(1000)
                 .startedAt(LocalDateTime.now())
                 .endedAt(LocalDateTime.now().plusDays(1))
                 .fileName("test.png")
@@ -161,5 +161,13 @@ public class Fixture {
         ReflectionTestUtils.setField(auction, "member", Fixture.createMember());
         ReflectionTestUtils.setField(auction, "viewCount", 2);
         return auction;
+    }
+
+    public static BiddingHistory createBiddingHistory(Long auctionId, Long memberId, int biddingPrice) {
+        return BiddingHistory.builder()
+                .auctionId(auctionId)
+                .memberId(memberId)
+                .price(biddingPrice)
+                .build();
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -79,4 +79,8 @@ public class FixtureDto {
                 LocalDateTime.now(),
                 LocalDateTime.now().plusDays(1));
     }
+
+    public static BiddingRequest createBiddingRequest(int biddingPrice) {
+        return new BiddingRequest(biddingPrice);
+    }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.Fixture.FixtureDto;
 import freshtrash.freshtrashbackend.config.TestSecurityConfig;
 import freshtrash.freshtrashbackend.dto.request.AuctionRequest;
+import freshtrash.freshtrashbackend.dto.request.BiddingRequest;
 import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
@@ -73,7 +74,8 @@ class AuctionApiTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.title").value(auctionRequest.title()))
-                .andExpect(jsonPath("$.content").value(auctionRequest.content()));
+                .andExpect(jsonPath("$.content").value(auctionRequest.content()))
+                .andExpect(jsonPath("$.minimumBid").value(auctionRequest.minimumBid()));
         // then
     }
 
@@ -115,6 +117,23 @@ class AuctionApiTest {
         willDoNothing().given(auctionService).deleteAuction(auctionId, userRole, memberId);
         // when
         mvc.perform(delete("/api/v1/auctions/" + auctionId)).andExpect(status().isNoContent());
+        // then
+    }
+
+    @DisplayName("경매 입찰 요청")
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void bidding() throws Exception {
+        // given
+        Long auctionId = 2L, memberId = 123L;
+        int biddingPrice = 10000;
+        BiddingRequest biddingRequest = FixtureDto.createBiddingRequest(biddingPrice);
+        willDoNothing().given(auctionService).requestBidding(auctionId, biddingPrice, memberId);
+        // when
+        mvc.perform(put("/api/v1/auctions/" + auctionId + "/bid")
+                        .content(objectMapper.writeValueAsString(biddingRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
         // then
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
@@ -1,0 +1,58 @@
+package freshtrash.freshtrashbackend.integration;
+
+import freshtrash.freshtrashbackend.Fixture.FixtureDto;
+import freshtrash.freshtrashbackend.config.TestSecurityConfig;
+import freshtrash.freshtrashbackend.controller.AuctionApi;
+import freshtrash.freshtrashbackend.dto.request.BiddingRequest;
+import freshtrash.freshtrashbackend.service.AuctionService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@SpringBootTest
+@Import(TestSecurityConfig.class)
+public class AuctionIntegrationTest {
+    @Autowired
+    AuctionApi auctionApi;
+
+    @Autowired
+    AuctionService auctionService;
+
+    @Test
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    void bidding() {
+        // given
+        int numThreads = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        Random random = new Random();
+        Long auctionId = 2L;
+        // when
+        for (int i = 0; i < 10; i++) {
+            executorService.execute(() -> {
+                int price = random.nextInt((5000 - 1000) + 1) + 1000;
+                log.info("Bidding price: {}", price);
+                auctionApi.placeBidding(auctionId, new BiddingRequest(price), FixtureDto.createMemberPrincipal());
+                latch.countDown();
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        // then
+        int finalBiddingPrice = auctionService.getAuction(auctionId).getFinalBid();
+        log.info("final bidding price: {}", finalBiddingPrice);
+    }
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 사용자가 특정 경매에 대해 입찰 요청할 수 있는 기능을 구현합니다. 요청 시 다음과 같은 조건을 고려해야합니다.
  - 요청한 입찰가는 이전 입찰가보다 높아야합니다.
  - 경매를 올린 사용자는 입찰이 불가능합니다.
  - 경매가 시작하기 전 또는 후에는 입찰이 불가능합니다.

- 경매 입찰이 정상적으로 반영되었을 경우 입찰 기록을 DB에 저장해야합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- `BiddingHistory` 엔티티 및 레포지토리 추가
- Auction 엔티티에 `@Version`을 적용한 version 속성을 추가하여 낙관적 락 적용

- 경매 입찰 기능 구현

    - 입찰 요청 시 방어 로직 추가
      - 요청한 입찰가는 이전 입찰가보다 높아야합니다.
      - 경매를 올린 사용자는 입찰이 불가능합니다.
      - 경매가 시작하기 전 또는 후에는 입찰이 불가능합니다.

    - 여러 사용자가 동시에 입찰을 시도할 경우 낙관적 락 `OPTIMISTIC` 옵션 적용
      - READ level에서 lock을 적용하여 잘못된 값을 조회하지 않도록 적용했습니다.
      - 낙관적 락 적용으로 인해 Exception(`ObjectOptimisticLockingFailureException`, `CannotAcquireLockException`)이 발생할 경우 Retry를 적용했습니다.
        - `BackOff`를 적용하여 1초 delay를 시작으로 최대 5초까지 delay를 적용했습니다.
        - 최대 3번 retry를 적용했습니다.
        - `Spring Retry`는 `Spring AMQP`에서 내부적으로 내부적으로 지원하기 때문에 따로 dependency를 추가하지 않았습니다.
    
    - 입찰 금액 업데이트 후 입찰 기록 저장
      - DB에서 출돌나지 않고 입찰 금액이 정상적으로 업데이트되었을 경우 입찰 기록(BiddingHistory)를 저장합니다.

      <img width="1333" alt="image" src="https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/c97e5400-c251-48dc-b22b-1adea992eeb4">

- 테스트 코드 작성
    - 통합 테스트를 통해 입찰 요청에서 발생할 수 있는 동시성 문제 해결을 확인할 수 있습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- Auction의 최종 낙찰 금액에 해당하는 minBid -> finalBid로 직관적으로 수정했습니다.

- `BindException`을 처리하기위한 `ExceptionHandler`를 추가했습니다.

- 테스트에서도 lombok을 사용하기위해 dependency를 추가했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #162 
