### PR TITLE
프로필 이미지 삭제 로직 추가

### DIFF
--- a/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/MemberService.java
@@ -114,6 +114,10 @@ public class MemberService {
             // 수정된 파일 저장
             fileService.uploadFile(imgFile, updatedFileName);
         }
+        // 파일이 유효하지 않을 경우 삭제
+        else {
+            member.setFileName(null);
+        }
         memberCacheRepository.save(MemberPrincipal.fromEntity(member));
 
         return member;

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
@@ -75,7 +75,7 @@ class AuctionApiTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.title").value(auctionRequest.title()))
                 .andExpect(jsonPath("$.content").value(auctionRequest.content()))
-                .andExpect(jsonPath("$.minimumBid").value(auctionRequest.minimumBid()));
+                .andExpect(jsonPath("$.finalBid").value(auctionRequest.minimumBid()));
         // then
     }
 

--- a/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.controller.AuctionApi;
 import freshtrash.freshtrashbackend.dto.request.BiddingRequest;
 import freshtrash.freshtrashbackend.service.AuctionService;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +20,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Slf4j
+@Disabled
 @SpringBootTest
 @Import(TestSecurityConfig.class)
 public class AuctionIntegrationTest {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제
- 기존에는 프로필 수정 시 imgFile이 null 값으로 들어오면 이전 프로필 사진을 그대로 사용하도록 적용되어 있었습니다. 하지만 프로필 이미지를 삭제하고 싶어하는 유저가 있을 수 있기 때문에 이와 관련하여 요구사항이 추가됨에따라 프로필 이미지 삭제 로직을 추가하도록 합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- Member 수정 시 프로필 이미지 삭제 기능 추가
  - 요구사항 추가에 따라 `imgFile`이 null 값으로 들어오거나 비어있는 파일이 들어오면 프로필 이미지를 삭제하도록 반영했습니다.
  - 이미지 삭제 후 반환되는 response의 `fileName`은 null 값을 가집니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 테스트 코드 수정
  - 통합 테스트는 전체 테스트 수행 시 disable 되도록 처리했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #164 
