### PR TITLE
경매 입찰 로직 실행 시 동시성 문제

### DIFF
--- a/database/mariadb/conf.d/mariadb.cnf
+++ b/database/mariadb/conf.d/mariadb.cnf
@@ -1,13 +1,3 @@
-[client]
-default-character-set = utf8mb4
-
-[mysql]
-default-character-set = utf8mb4
-
-[mysqld]
+[mariadb]
 port = 3307
-character-set-server  = utf8mb4
-collation-server      = utf8mb4_unicode_ci
-
-[mysqldump]
-default-character-set = utf8mb4
+transaction_isolation = READ-COMMITTED

--- a/database/mariadb/initdb.d/create_table.sql
+++ b/database/mariadb/initdb.d/create_table.sql
@@ -144,7 +144,7 @@ CREATE TABLE `auctions`
     `product_category` varchar(255)          NOT NULL,
     `product_status`   varchar(255)          NOT NULL,
     `auction_status`   varchar(255)          NOT NULL,
-    `final_bid`          integer               NOT NULL,
+    `final_bid`        integer               NOT NULL,
     `view_count`       integer               NOT NULL,
     `started_at`       datetime              NOT NULL,
     `ended_at`         datetime              NOT NULL,
@@ -157,12 +157,12 @@ CREATE TABLE `auctions`
 
 CREATE TABLE `bidding_history`
 (
-    `id` bigint AUTO_INCREMENT NOT NULL ,
-    `member_id` bigint NOT NULL ,
-    `auction_id` bigint NOT NULL ,
-    `price` integer NOT NULL ,
-    `is_success_bidding` tinyint(1) NOT NULL ,
-    `created_at` datetime NOT NULL ,
+    `id`                 bigint AUTO_INCREMENT NOT NULL,
+    `member_id`          bigint                NOT NULL,
+    `auction_id`         bigint                NOT NULL,
+    `price`              integer               NOT NULL,
+    `is_success_bidding` tinyint(1)            NOT NULL,
+    `created_at`         datetime              NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`auction_id`) references auctions (id) on delete cascade

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
     FORBIDDEN_AUCTION(HttpStatus.FORBIDDEN, "경매에 대한 권한이 없습니다."),
     INVALID_AUCTION_TIME(HttpStatus.BAD_REQUEST, "경매 시간이 잘못되었습니다."),
     WRITER_CANT_BIDDING(HttpStatus.BAD_REQUEST, "경매 등록 사용자는 입찰할 수 없습니다."),
-    INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "요청 입찰가는 기존 입찰가보다 커야합니다."),
+    INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "요청 입찰가는 기존 입찰가보다 커야하고 최소 10원 단위의 금액을 입력해야합니다."),
     CANT_BIDDING_TIME(HttpStatus.BAD_REQUEST, "지금은 경매 중이 아닙니다.");
 
     private final HttpStatus status;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,12 @@ spring:
         - file
         - mail
         - security
+      integration_test:
+        - common
+        - amqp
+        - file
+        - mail
+        - security
       test:
         - file
         - mail
@@ -29,6 +35,22 @@ spring:
   devtools.livereload:
     enabled: true
     port: 35730
+
+---
+
+spring:
+  config.activate.on-profile: integration_test
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  devtools.livereload:
+    enabled: true
+    port: 35730
+logging:
+  level:
+    org.springframework.transaction: debug
+    org.springframework.orm.jpa: debug
+    freshtrash.freshtrashbackend: debug
 
 ---
 

--- a/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
@@ -6,13 +6,13 @@ import freshtrash.freshtrashbackend.controller.AuctionApi;
 import freshtrash.freshtrashbackend.dto.request.BiddingRequest;
 import freshtrash.freshtrashbackend.service.AuctionService;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -20,7 +20,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Slf4j
-@Disabled
+// @Disabled
+@ActiveProfiles("integration_test")
 @SpringBootTest
 @Import(TestSecurityConfig.class)
 public class AuctionIntegrationTest {
@@ -32,21 +33,22 @@ public class AuctionIntegrationTest {
 
     @Test
     @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-    void bidding() {
+    void bidding() throws InterruptedException {
         // given
-        int numThreads = 10;
+        int numThreads = 2;
         ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
         CountDownLatch latch = new CountDownLatch(numThreads);
         Random random = new Random();
         Long auctionId = 2L;
         // when
-        for (int i = 0; i < 10; i++) {
+        for (int i = 1; i <= numThreads; i++) {
             executorService.execute(() -> {
-                int price = random.nextInt((5000 - 1000) + 1) + 1000;
-                log.info("Bidding price: {}", price);
-                auctionApi.placeBidding(auctionId, new BiddingRequest(price), FixtureDto.createMemberPrincipal());
-                latch.countDown();
                 try {
+                    int price = random.nextInt((5000 - 1000) + 1) + 1000;
+                    price -= price % 10;
+                    log.info("Bidding price: {}", price);
+                    auctionApi.placeBidding(auctionId, new BiddingRequest(price), FixtureDto.createMemberPrincipal());
+                    latch.countDown();
                     latch.await();
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
@@ -54,6 +56,7 @@ public class AuctionIntegrationTest {
             });
         }
         // then
+        Thread.sleep(2000);
         int finalBiddingPrice = auctionService.getAuction(auctionId).getFinalBid();
         log.info("final bidding price: {}", finalBiddingPrice);
     }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 여러 사용자가 동시에 경매 입찰을 요청하게 될 경우 동시성 문제가 발생할 수 있습니다. 예를 들어, A가 더 높은 금액을 제시했음에도 B의 금액이 반영될 수가 있을 수 있습니다. 이러한 문제를 구체적으로 정의하고 가장 적절한 방법을 찾아 적용해야합니다.
- 구체적인 문제와 내용은 하단의 링크를 통해 확인할 수 있습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- LockMode를 OPTIMISTIC -> NONE으로 설정
  - 커밋할 때도 버전 정보를 확인할 필요는 없어 update 쿼리 수행 시에만 버전을 확인하도록 적용했습니다.
  - 예외가 발생하면 retry가 최대 3회 적용됩니다.

- retry의 delay 설정 수정
  - 1초 ~ 5초는 생각보다 긴 시간이어서 300ms ~ 700ms로 임의로 수정했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 입찰 요청 금액이 최소 10원 단위인지 확인하는 조건 추가
- 통합 테스트 수정
    - 통합 테스트를 위한 프로필 설정을 추가했습니다.
- mariadb configuration 수정
    - isolation level을 `READ-COMMITTED`로 변경했습니다.
    - 기본으로 설정된 `REPEATABLE-READ`의 경우 Non-Repeatable Read 문제를 해결했지만, 현재 서비스에서는 조회를 할 때마다 같은 값을 조회하는 것보다 변경된 값을 조회하는 것이 더 적절한 것 같다고 판단했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #166 

## Reference Link
- https://kjy042386.tistory.com/543
