### PR TITLE
경매 낙찰 처리 기능 추가

### DIFF
--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -16,8 +16,8 @@ values ('abc@never.com', '$2a$10$ZskRs64yZZU9g6blmNdZte7FO6KaMduwlZhk7YkxJX2ZwYL
 
 
 insert into products(member_id, title, content, product_price, like_count, view_count, file_name, product_category,
-                   product_status,
-                   sell_status, address, created_at, modified_at, product_deal_at)
+                     product_status,
+                     sell_status, address, created_at, modified_at, product_deal_at)
 values (1, 'title', 'content', 0, 1, 0, 'test.png', 'CLOTHING', 'GOOD', 'ONGOING',
         json_object('zipcode', '12345', 'state', 'state', 'city', 'city', 'district', 'district', 'detail', 'detail'),
         now(), null, null),
@@ -152,10 +152,14 @@ values (1, 'CHAT', json_object('fromMemberId', 2, 'targetId', 1), '거래 완료
        (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 1), 'user123님이 판매중으로 변경하였습니다.', now(), null, null),
        (1, 'CHAT', json_object('fromMemberId', 2, 'targetId', 5), '거래 완료되었습니다.', now(), now(), null),
        (1, 'CHAT', json_object('fromMemberId', 1, 'targetId', 6), '알람 테스트', now(), now(), null),
-       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 예약중으로 변경하였습니다.', now(), now(), null),
-       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 판매중으로 변경하였습니다.', now(), now(), null),
-       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 예약중으로 변경하였습니다.', now(), now(), null),
-       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 판매중으로 변경하였습니다.', now(), now(), null),
+       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 예약중으로 변경하였습니다.', now(), now(),
+        null),
+       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 판매중으로 변경하였습니다.', now(), now(),
+        null),
+       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 예약중으로 변경하였습니다.', now(), now(),
+        null),
+       (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 5), 'user123님이 판매중으로 변경하였습니다.', now(), now(),
+        null),
        (1, 'TRANSACTION', json_object('fromMemberId', 3, 'targetId', 1), '거래 완료되었습니다.', now(), null, null),
        (1, 'TRANSACTION', json_object('fromMemberId', 4, 'targetId', 4), '예약중으로 변경하였습니다.', now(), null, null),
        (1, 'TRANSACTION', json_object('fromMemberId', 4, 'targetId', 4), '거래 완료되었습니다.', now(), null, null),
@@ -176,12 +180,17 @@ values (1, 'CHAT', json_object('fromMemberId', 2, 'targetId', 1), '거래 완료
        (5, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), 'abc님이 판매중으로 변경하였습니다.', now(), null, null),
        (1, 'TRANSACTION', json_object('fromMemberId', 1, 'targetId', 1), 'abc님이 판매중으로 변경하였습니다.', now(), null, now());
 
-insert into auctions(member_id, file_name, title, content, product_category, product_status, auction_status, final_bid, view_count, started_at, ended_at, created_at) values
-(1, 'test.png', 'title', 'content', 'CLOTHING', 'GOOD', 'ONGOING', 1000, 1, now(), date_add(now(), interval 1 hour), now()),
-(2, 'test.png', 'title2', 'content2', 'HEALTH', 'GOOD', 'ONGOING', 1000, 3, now(), date_add(now(), interval 1 hour), now()),
-(3, 'test.png', 'title3', 'content3', 'SPORTS', 'GOOD', 'CLOSE', 3000, 5, now(), date_add(now(), interval 1 hour), now());
+insert into auctions(member_id, file_name, title, content, product_category, product_status, auction_status, final_bid,
+                     view_count, started_at, ended_at, created_at)
+values (1, 'test.png', 'title', 'content', 'CLOTHING', 'GOOD', 'ONGOING', 1000, 1, now(),
+        date_add(now(), interval 1 hour), now()),
+       (2, 'test.png', 'title2', 'content2', 'HEALTH', 'GOOD', 'ONGOING', 1000, 3, now(),
+        date_add(now(), interval 1 hour), now()),
+       (3, 'test.png', 'title3', 'content3', 'SPORTS', 'GOOD', 'CLOSE', 3000, 5, now(),
+        date_add(now(), interval 1 hour), now()),
+       (4, 'test.png', 'title4', 'content4', 'SPORTS', 'GOOD', 'ONGOING', 3000, 5, now(), now(), now());
 
-insert into bidding_history(member_id, auction_id, price, is_success_bidding, created_at) values
-(2, 1, 1000, true, now()),
-(1, 2, 1000, false, now()),
-(1, 3, 3000, true, now());
+insert into bidding_history(member_id, auction_id, price, is_success_bidding, created_at)
+values (2, 1, 1000, true, now()),
+       (1, 2, 1000, false, now()),
+       (1, 3, 3000, true, now());

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
@@ -11,6 +11,10 @@ import static freshtrash.freshtrashbackend.config.rabbitmq.QueueType.*;
 
 @Configuration
 public class BindingConfig {
+
+    /**
+     * Queue Binding
+     */
     @Bean
     Binding productCompleteBinding(Queue productCompleteQueue, TopicExchange topicExchange) {
         return createBinding(productCompleteQueue, topicExchange, PRODUCT_TRANSACTION_COMPLETE.getRoutingKey());
@@ -32,6 +36,14 @@ public class BindingConfig {
     }
 
     @Bean
+    Binding auctionCompleteBinding(Queue auctionCompleteQueue, TopicExchange topicExchange) {
+        return createBinding(auctionCompleteQueue, topicExchange, AUCTION_BID_COMPLETE.getRoutingKey());
+    }
+
+    /**
+     * DLQ Binding
+     */
+    @Bean
     Binding dlqProductCompleteBinding(Queue dlqProductCompleteQueue, TopicExchange dlqExchange) {
         return createBinding(dlqProductCompleteQueue, dlqExchange, DLQ_PRODUCT_TRANSACTION_COMPLETE.getRoutingKey());
     }
@@ -52,6 +64,14 @@ public class BindingConfig {
     }
 
     @Bean
+    Binding dlqAuctionCompleteBinding(Queue dlqAuctionCompleteQueue, TopicExchange dlqExchange) {
+        return createBinding(dlqAuctionCompleteQueue, dlqExchange, DLQ_AUCTION_BID_COMPLETE.getRoutingKey());
+    }
+
+    /**
+     * Parking Lot Queue Binding
+     */
+    @Bean
     Binding productParkingLotBinding(Queue productParkingLotQueue, TopicExchange parkingLotExchange) {
         return createBinding(productParkingLotQueue, parkingLotExchange, PRODUCT_PARKING_LOT.getRoutingKey());
     }
@@ -59,6 +79,11 @@ public class BindingConfig {
     @Bean
     Binding chatParkingLotBinding(Queue chatParkingLotQueue, TopicExchange parkingLotExchange) {
         return createBinding(chatParkingLotQueue, parkingLotExchange, CHAT_PARKING_LOT.getRoutingKey());
+    }
+
+    @Bean
+    Binding auctionParkingLotBinding(Queue auctionParkingLotQueue, TopicExchange parkingLotExchange) {
+        return createBinding(auctionParkingLotQueue, parkingLotExchange, AUCTION_PARKING_LOT.getRoutingKey());
     }
 
     private Binding createBinding(Queue queue, TopicExchange exchange, String routingKey) {

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
@@ -38,6 +38,11 @@ public class QueueConfig {
         return createQueueWithDLQ(CHAT, DLQ_CHAT);
     }
 
+    @Bean
+    Queue auctionCompleteQueue() {
+        return createQueueWithDLQ(AUCTION_BID_COMPLETE, DLQ_AUCTION_BID_COMPLETE);
+    }
+
     /**
      * DLQ
      */
@@ -61,6 +66,11 @@ public class QueueConfig {
         return createQueue(DLQ_CHAT);
     }
 
+    @Bean
+    Queue dlqAuctionCompleteQueue() {
+        return createQueue(DLQ_AUCTION_BID_COMPLETE);
+    }
+
     /**
      * Parking Lot Queue
      */
@@ -72,6 +82,11 @@ public class QueueConfig {
     @Bean
     Queue chatParkingLotQueue() {
         return createQueue(CHAT_PARKING_LOT);
+    }
+
+    @Bean
+    Queue auctionParkingLotQueue() {
+        return createQueue(AUCTION_PARKING_LOT);
     }
 
     private Queue createQueueWithDLQ(QueueType queueType, QueueType dlqType) {

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
@@ -11,16 +11,19 @@ public enum QueueType {
     PRODUCT_CHANGE_SELL_STATUS("queue.product.changeStatus", "product.change.sellStatus"),
     PRODUCT_TRANSACTION_FLAG("queue.product.flag", "product.productDeal.flag"),
     CHAT("queue.chat", "chats.#"),
+    AUCTION_BID_COMPLETE("queue.auction.complete", "auction.bid.complete"),
 
     // DLQ
     DLQ_PRODUCT_TRANSACTION_COMPLETE("queue.product.complete.dlq", "product.productDeal.complete"),
     DLQ_PRODUCT_CHANGE_SELL_STATUS("queue.product.changeStatus.dlq", "product.change.sellStatus"),
     DLQ_PRODUCT_TRANSACTION_FLAG("queue.product.flag.dlq", "product.productDeal.flag"),
     DLQ_CHAT("queue.chat.dlq", "chats.#"),
+    DLQ_AUCTION_BID_COMPLETE("queue.auction.complete.dlq", "auction.bid.complete"),
 
     // Parking Lot
     PRODUCT_PARKING_LOT("queue.product.parking-lot", "product.#"),
-    CHAT_PARKING_LOT("queue.chat.parking-lot", "chats.#");
+    CHAT_PARKING_LOT("queue.chat.parking-lot", "chats.#"),
+    AUCTION_PARKING_LOT("queue.auction.parking-lot", "auction.#");
 
     private final String name;
     private final String routingKey;

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/AuctionAlarmConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/AuctionAlarmConsumer.java
@@ -17,18 +17,17 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ProductAlarmConsumer {
+public class AuctionAlarmConsumer {
     private final AlarmService alarmService;
 
     /**
-     * 중고 상품 알람 메시지 전송 Listener
+     * 경매 알람 메시지 전송 Listener
      */
     @ManualAcknowledge
-    @RabbitListener(
-            queues = {"#{productCompleteQueue.name}", "#{productFlagQueue.name}", "#{productChangeStatusQueue.name}"})
-    public void consumeProductDealMessage(
+    @RabbitListener(queues = {"#{auctionCompleteQueue.name}"})
+    public void consumeAuctionMessage(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload AlarmPayload alarmPayload) {
-        log.debug("receive complete productDeal message: {}", alarmPayload);
+        log.debug("receive complete bid auction message: {}", alarmPayload);
         Alarm alarm = alarmService.saveAlarm(alarmPayload);
         alarmService.receive(alarmPayload.memberId(), AlarmResponse.fromEntity(alarm));
     }

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
@@ -24,7 +24,8 @@ public class DeadLetterConsumer {
                 "#{dlqProductCompleteQueue.name}",
                 "#{dlqProductFlagQueue.name}",
                 "#{dlqProductChangeStatusQueue.name}",
-                "#{dlqChatQueue.name}"
+                "#{dlqChatQueue.name}",
+                "#{dlqAuctionCompleteQueue.name}"
             })
     public void handleFailedProductDealMessage(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, Message message) {

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/ParkingLotConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/ParkingLotConsumer.java
@@ -22,7 +22,9 @@ public class ParkingLotConsumer {
      * Product Parking Lot Listener
      */
     @ManualAcknowledge
-    @RabbitListener(queues = {"#{productParkingLotQueue.name}", "#{chatParkingLotQueue.name}"})
+    @RabbitListener(
+            queues = {"#{productParkingLotQueue.name}", "#{chatParkingLotQueue.name}", "#{auctionParkingLotQueue.name}"
+            })
     public void handleProductParkingLot(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload AlarmPayload alarmPayload) {
         log.warn("consume from parking lot");

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
@@ -12,7 +12,7 @@ public enum AlarmMessage {
     UPDATED_ONGOING_MESSAGE("%s님이 판매중으로 판매상태를 변경하였습니다."),
     FLAG_MESSAGE("%d번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다."),
     EXCEED_FLAG_MESSAGE("10번이상 신고받으셔서 더이상 서비스를 이용하실 수 없습니다."),
-    NOT_COMPLETE_AUCTION("겅매 [%s]가 입찰된 내역이 없습니다."),
+    NOT_COMPLETED_AUCTION("겅매 [%s]가 입찰된 내역이 없습니다."),
     COMPLETE_BID_AUCTION("경매 [%s]가 낙찰되었습니다."),
     REQUEST_PAY_AUCTION("경매 [%s]가 낙찰되었습니다. 24시간 이내에 결제바랍니다.");
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
@@ -11,6 +11,9 @@ public enum AlarmMessage {
     UPDATED_BOOKING_MESSAGE("%s님이 예약중으로 판매상태를 변경하였습니다."),
     UPDATED_ONGOING_MESSAGE("%s님이 판매중으로 판매상태를 변경하였습니다."),
     FLAG_MESSAGE("%d번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다."),
-    EXCEED_FLAG_MESSAGE("10번이상 신고받으셔서 더이상 서비스를 이용하실 수 없습니다.");
+    EXCEED_FLAG_MESSAGE("10번이상 신고받으셔서 더이상 서비스를 이용하실 수 없습니다."),
+    NOT_COMPLETE_AUCTION("겅매 [%s]가 입찰된 내역이 없습니다."),
+    COMPLETE_BID_AUCTION("경매 [%s]가 낙찰되었습니다."),
+    REQUEST_PAY_AUCTION("경매 [%s]가 낙찰되었습니다. 24시간 이내에 결제바랍니다.");
     private final String message;
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AlarmPayload.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AlarmPayload.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.dto.request;
 
+import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.entity.constants.AlarmType;
 import lombok.Builder;
@@ -8,16 +9,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Builder
-public record AlarmPayload(String message, Long productId, Long memberId, Long fromMemberId, AlarmType alarmType) {
+public record AlarmPayload(String message, Long targetId, Long memberId, Long fromMemberId, AlarmType alarmType) {
     public Map<String, String> toMap() {
         Map<String, String> data = new HashMap<>();
-        data.put("productId", productId.toString());
+        data.put("productId", targetId.toString());
         data.put("memberId", memberId.toString());
         data.put("fromMemberId", fromMemberId.toString());
         data.put("alarmType", alarmType.name());
         return data;
     }
 
+    /**
+     * 구매자에의해 구매되었음을 판매자에게 알림
+     */
     public static AlarmPayload ofProductDealByBuyer(String message, ChatRoom chatRoom, AlarmType alarmType) {
         return ofProductDeal(message, chatRoom, alarmType)
                 .memberId(chatRoom.getSellerId())
@@ -25,6 +29,9 @@ public record AlarmPayload(String message, Long productId, Long memberId, Long f
                 .build();
     }
 
+    /**
+     * 판매자가 올린 상품이 거래되었음을 구매자에게 알림
+     */
     public static AlarmPayload ofProductDealBySeller(String message, ChatRoom chatRoom, AlarmType alarmType) {
         return ofProductDeal(message, chatRoom, alarmType)
                 .memberId(chatRoom.getBuyerId())
@@ -32,20 +39,56 @@ public record AlarmPayload(String message, Long productId, Long memberId, Long f
                 .build();
     }
 
+    /**
+     * 현재 사용자에의해 특정 사용자가 신고되었음을 알림
+     */
     public static AlarmPayload ofUserFlag(String message, Long productId, Long targetMemberId, Long currentMemberId) {
         return AlarmPayload.builder()
                 .message(message)
-                .productId(productId)
+                .targetId(productId)
                 .memberId(targetMemberId)
                 .fromMemberId(currentMemberId)
                 .alarmType(AlarmType.FLAG)
                 .build();
     }
 
+    /**
+     * 경매가 입찰되지 않았음을 알림
+     */
+    public static AlarmPayload ofAuctionNotBid(String message, Auction auction) {
+        return ofAuctionBid(message, auction, AlarmType.BIDDING)
+                .memberId(auction.getMemberId())
+                .build();
+    }
+
+    /**
+     * 경매가 낙찰되었음을 판매자에게 알림
+     */
+    public static AlarmPayload ofAuctionBidByBuyer(String message, Auction auction, Long fromMemberId) {
+        return ofAuctionBid(message, auction, AlarmType.BIDDING)
+                .memberId(auction.getMemberId())
+                .fromMemberId(fromMemberId)
+                .build();
+    }
+
+    /**
+     * 경매가 낙찰되어 결제 요청을 구매자에게 알림
+     */
+    public static AlarmPayload ofAuctionBidBySeller(String message, Auction auction, Long fromMemberId) {
+        return ofAuctionBid(message, auction, AlarmType.BIDDING)
+                .memberId(fromMemberId)
+                .fromMemberId(auction.getMemberId())
+                .build();
+    }
+
     private static AlarmPayloadBuilder ofProductDeal(String message, ChatRoom chatRoom, AlarmType alarmType) {
         return AlarmPayload.builder()
                 .message(message)
-                .productId(chatRoom.getProductId())
+                .targetId(chatRoom.getProductId())
                 .alarmType(alarmType);
+    }
+
+    private static AlarmPayloadBuilder ofAuctionBid(String message, Auction auction, AlarmType alarmType) {
+        return AlarmPayload.builder().message(message).targetId(auction.getId()).alarmType(alarmType);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
@@ -66,7 +66,7 @@ public class Alarm extends CreatedAt {
                 .message(alarmPayload.message())
                 .memberId(alarmPayload.memberId())
                 .alarmType(alarmPayload.alarmType())
-                .alarmArgs(AlarmArgs.of(alarmPayload.fromMemberId(), alarmPayload.productId()))
+                .alarmArgs(AlarmArgs.of(alarmPayload.fromMemberId(), alarmPayload.targetId()))
                 .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
@@ -22,7 +22,7 @@ import static javax.persistence.FetchType.LAZY;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @TypeDef(name = "json", typeClass = JsonType.class)
-@SQLDelete(sql = "update alarms set deleted_at = now() where id=?")
+@SQLDelete(sql = "update alarms set deleted_at = current_timestamp where id=?")
 @Where(clause = "deleted_at is NULL")
 public class Alarm extends CreatedAt {
     @Id

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
@@ -9,6 +9,8 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import static javax.persistence.FetchType.LAZY;
 
@@ -68,6 +70,11 @@ public class Auction extends CreatedAt {
 
     @Column(nullable = false)
     private Long memberId;
+
+    @ToString.Exclude
+    @OrderBy("createdAt DESC")
+    @OneToMany(mappedBy = "auction", cascade = CascadeType.ALL, fetch = LAZY)
+    private Set<BiddingHistory> biddingHistories = new LinkedHashSet<>();
 
     @Version
     private int version;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
@@ -4,7 +4,7 @@ public enum AlarmType {
     CHAT, // 채팅 알림
     TRANSACTION, // 거래 상태 변경 시 알림
     BOOKING_REQUEST, // 예약 요청 알림
-    BIDDING, // 최종 입찰자 알림
+    BIDDING, // 낙찰 알림
     PAY, // 결제 완료 알림
     RECEIVE, // 상품 수령 알림
     NOT_PAY, // 미결제 알림

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Page<Alarm> findAllByMember_Id(Long memberId, Pageable pageable);
 
-    @Query(nativeQuery = true, value = "update alarms a set a.read_at = now() where a.id = ?1 and a.read_at is null")
+    @Query(nativeQuery = true, value = "update alarms a set a.read_at = current_timestamp where a.id = ?1 and a.read_at is null")
     void updateReadAtById(Long alarmId);
 
     boolean existsByIdAndMember_Id(Long alarmId, Long memberId);

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
@@ -9,12 +9,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Transactional(propagation = Propagation.SUPPORTS)
@@ -35,4 +37,11 @@ public interface AuctionRepository
     Optional<Auction> findById(Long auctionId);
 
     boolean existsByIdAndMemberId(Long auctionId, Long memberId);
+
+    @EntityGraph(attributePaths = "biddingHistories")
+    @Query("select a from Auction a where a.auctionStatus = 'ONGOING' and a.endedAt < now()")
+    List<Auction> findAllEndedAuctions();
+
+    @Query(nativeQuery = true, value = "update auctions a set a.auction_status = 'CLOSE' where a.id = ?1")
+    void updateCloseById(Long id);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
@@ -39,7 +39,7 @@ public interface AuctionRepository
     boolean existsByIdAndMemberId(Long auctionId, Long memberId);
 
     @EntityGraph(attributePaths = "biddingHistories")
-    @Query("select a from Auction a where a.auctionStatus = 'ONGOING' and a.endedAt < now()")
+    @Query("select a from Auction a where a.auctionStatus = 'ONGOING' and a.endedAt < current_timestamp")
     List<Auction> findAllEndedAuctions();
 
     @Query(nativeQuery = true, value = "update auctions a set a.auction_status = 'CLOSE' where a.id = ?1")

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
@@ -43,5 +43,5 @@ public interface AuctionRepository
     List<Auction> findAllEndedAuctions();
 
     @Query(nativeQuery = true, value = "update auctions a set a.auction_status = 'CLOSE' where a.id = ?1")
-    void updateCloseById(Long id);
+    void closeAuctionById(Long id);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -20,8 +20,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findByProduct_IdAndSellStatusNot(Long productId, SellStatus sellStatus);
 
-    List<BuyerIdSummary> findBuyerIdByProductIdAndBuyerIdNot(Long productId, Long buyerId);
-
     @EntityGraph(attributePaths = {"product", "buyer", "seller", "chatMessages"})
     Optional<ChatRoom> findById(Long chatRoomId);
 

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionEventService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionEventService.java
@@ -1,0 +1,25 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.alarm.CompleteBidAuctionAlarm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuctionEventService {
+    private final AuctionService auctionService;
+    private final CompleteBidAuctionAlarm completeBidAuctionAlarm;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void completeAuction() {
+        List<Auction> auctions = auctionService.getEndedAuctions();
+        // 입찰자 여부를 확인하고 입찰자가 없으면 구매자에게 알림, 있으면 판매자에게 알림
+        auctions.forEach(completeBidAuctionAlarm::sendAlarm);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionEventService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionEventService.java
@@ -17,7 +17,7 @@ public class AuctionEventService {
     private final CompleteBidAuctionAlarm completeBidAuctionAlarm;
 
     @Scheduled(cron = "0 0 0 * * *")
-    public void completeAuction() {
+    public void processCompletedAuctions() {
         List<Auction> auctions = auctionService.getEndedAuctions();
         // 입찰자 여부를 확인하고 입찰자가 없으면 구매자에게 알림, 있으면 판매자에게 알림
         auctions.forEach(completeBidAuctionAlarm::sendAlarm);

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 
@@ -86,6 +87,16 @@ public class AuctionService {
         auction.setFinalBid(biddingPrice);
         // 입찰 기록
         addBiddingHistory(auctionId, memberId, biddingPrice);
+    }
+
+    public void closeAuction(Long auctionId) {
+        log.debug("경매 판매 상태를 CLOSE로 변경");
+        auctionRepository.updateCloseById(auctionId);
+    }
+
+    public List<Auction> getEndedAuctions() {
+        log.debug("마감되었지만 AuctionStatus가 ONGOING인 경매 조회");
+        return auctionRepository.findAllEndedAuctions();
     }
 
     private void validateBiddingRequest(Auction auction, int biddingPrice, Long memberId) {

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
@@ -91,7 +91,7 @@ public class AuctionService {
 
     public void closeAuction(Long auctionId) {
         log.debug("경매 판매 상태를 CLOSE로 변경");
-        auctionRepository.updateCloseById(auctionId);
+        auctionRepository.closeAuctionById(auctionId);
     }
 
     public List<Auction> getEndedAuctions() {

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/AuctionAlarmTemplate.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/AuctionAlarmTemplate.java
@@ -1,0 +1,29 @@
+package freshtrash.freshtrashbackend.service.alarm;
+
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.AuctionService;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AuctionAlarmTemplate {
+    protected final AuctionService auctionService;
+    protected final AuctionPublisher producer;
+
+    public final void sendAlarm(Auction auction) {
+        update(auction.getId());
+        auction.getBiddingHistories().stream()
+                .findFirst()
+                .ifPresentOrElse(
+                        biddingHistory -> publishEvent(auction, biddingHistory.getMemberId()),
+                        () -> publishEvent(auction));
+    }
+
+    abstract void update(Long targetId);
+
+    abstract void publishEvent(Auction auction, Long bidMemberId);
+
+    abstract void publishEvent(Auction auction);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelBookingProductAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelBookingProductAlarm.java
@@ -5,6 +5,7 @@ import freshtrash.freshtrashbackend.entity.constants.AlarmType;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.service.ChatRoomService;
 import freshtrash.freshtrashbackend.service.ProductDealService;
+import freshtrash.freshtrashbackend.service.alarm.template.ProductAlarmTemplate;
 import freshtrash.freshtrashbackend.service.producer.ProductDealProducer;
 import org.springframework.stereotype.Component;
 
@@ -19,12 +20,12 @@ public class CancelBookingProductAlarm extends ProductAlarmTemplate {
     }
 
     @Override
-    void update(ChatRoom chatRoom) {
+    public void update(ChatRoom chatRoom) {
         this.productDealService.updateSellStatus(chatRoom.getProductId(), chatRoom.getId(), SellStatus.ONGOING);
     }
 
     @Override
-    void publishEvent(ChatRoom bookedChatRoom) {
+    public void publishEvent(ChatRoom bookedChatRoom) {
         String message = generateMessage(bookedChatRoom.getSeller().getNickname());
         this.chatRoomService
                 .getNotClosedChatRoomsByProductId(bookedChatRoom.getProductId())

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
@@ -2,6 +2,7 @@ package freshtrash.freshtrashbackend.service.alarm;
 
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.service.AuctionService;
+import freshtrash.freshtrashbackend.service.alarm.template.AuctionAlarmTemplate;
 import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,19 +16,19 @@ public class CompleteBidAuctionAlarm extends AuctionAlarmTemplate {
     }
 
     @Override
-    void update(Long auctionId) {
+    public void update(Long auctionId) {
         this.auctionService.closeAuction(auctionId);
     }
 
     @Override
-    void publishEvent(Auction auction, Long bidMemberId) {
+    public void publishEvent(Auction auction, Long bidMemberId) {
         log.debug("판매자에게 낙찰 알림, 구매자에게 결제 요청 알림");
         this.producer.completeBid(auction, bidMemberId);
         this.producer.requestPay(auction, bidMemberId);
     }
 
     @Override
-    void publishEvent(Auction auction) {
+    public void publishEvent(Auction auction) {
         log.debug("입찰자가 없음을 판매자에게 알림");
         this.producer.notCompleteBid(auction);
     }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
@@ -1,0 +1,34 @@
+package freshtrash.freshtrashbackend.service.alarm;
+
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.AuctionService;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CompleteBidAuctionAlarm extends AuctionAlarmTemplate {
+
+    public CompleteBidAuctionAlarm(AuctionService auctionService, AuctionPublisher producer) {
+        super(auctionService, producer);
+    }
+
+    @Override
+    void update(Long auctionId) {
+        this.auctionService.closeAuction(auctionId);
+    }
+
+    @Override
+    void publishEvent(Auction auction, Long bidMemberId) {
+        log.debug("판매자에게 낙찰 알림, 구매자에게 결제 요청 알림");
+        this.producer.completeBid(auction, bidMemberId);
+        this.producer.requestPay(auction, bidMemberId);
+    }
+
+    @Override
+    void publishEvent(Auction auction) {
+        log.debug("입찰자가 없음을 판매자에게 알림");
+        this.producer.notCompleteBid(auction);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteDealProductAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteDealProductAlarm.java
@@ -4,6 +4,7 @@ import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.service.ChatRoomService;
 import freshtrash.freshtrashbackend.service.ProductDealService;
+import freshtrash.freshtrashbackend.service.alarm.template.ProductAlarmTemplate;
 import freshtrash.freshtrashbackend.service.producer.ProductDealProducer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,7 +19,7 @@ public class CompleteDealProductAlarm extends ProductAlarmTemplate {
     }
 
     @Override
-    void update(ChatRoom closedChatRoom) {
+    public void update(ChatRoom closedChatRoom) {
         this.productDealService.completeProductDeal(
                 closedChatRoom.getProductId(),
                 closedChatRoom.getId(),
@@ -28,7 +29,7 @@ public class CompleteDealProductAlarm extends ProductAlarmTemplate {
     }
 
     @Override
-    void publishEvent(ChatRoom closedChatRoom) {
+    public void publishEvent(ChatRoom closedChatRoom) {
         // 판매자, 구매자에게 알람 전송
         this.producer.completeDeal(closedChatRoom);
         log.debug("Send message to seller.");

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/RequestBookingProductAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/RequestBookingProductAlarm.java
@@ -5,6 +5,7 @@ import freshtrash.freshtrashbackend.entity.constants.AlarmType;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
 import freshtrash.freshtrashbackend.service.ChatRoomService;
 import freshtrash.freshtrashbackend.service.ProductDealService;
+import freshtrash.freshtrashbackend.service.alarm.template.ProductAlarmTemplate;
 import freshtrash.freshtrashbackend.service.producer.ProductDealProducer;
 import org.springframework.stereotype.Component;
 
@@ -19,12 +20,12 @@ public class RequestBookingProductAlarm extends ProductAlarmTemplate {
     }
 
     @Override
-    void update(ChatRoom chatRoom) {
+    public void update(ChatRoom chatRoom) {
         this.productDealService.updateSellStatus(chatRoom.getProductId(), chatRoom.getId(), SellStatus.BOOKING);
     }
 
     @Override
-    void publishEvent(ChatRoom ongoingChatRoom) {
+    public void publishEvent(ChatRoom ongoingChatRoom) {
         String message = generateMessage(ongoingChatRoom.getSeller().getNickname());
         chatRoomService
                 .getNotClosedChatRoomsByProductId(ongoingChatRoom.getProductId())

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
@@ -1,6 +1,7 @@
 package freshtrash.freshtrashbackend.service.alarm;
 
 import freshtrash.freshtrashbackend.service.MemberService;
+import freshtrash.freshtrashbackend.service.alarm.template.ChatAlarmTemplate;
 import freshtrash.freshtrashbackend.service.producer.ChatProducer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -22,13 +23,13 @@ public class UserFlagChatAlarm extends ChatAlarmTemplate {
      * 유저 신고 횟수 + 1
      */
     @Override
-    int update(Long targetMemberId) {
+    public int update(Long targetMemberId) {
         log.debug("유저 신고 횟수 + 1 업데이트...");
         return this.memberService.updateFlagCount(targetMemberId, FLAG_LIMIT).flagCount();
     }
 
     @Override
-    void publishEvent(int flagCount, Long productId, Long targetMemberId, Long currentMemberId) {
+    public void publishEvent(int flagCount, Long productId, Long targetMemberId, Long currentMemberId) {
         log.debug("현재 신고 횟수 {}", flagCount);
         String message = generateMessage(flagCount);
         this.producer.occurredUserFlag(productId, targetMemberId, currentMemberId, message);

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/AuctionAlarmTemplate.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/AuctionAlarmTemplate.java
@@ -1,4 +1,4 @@
-package freshtrash.freshtrashbackend.service.alarm;
+package freshtrash.freshtrashbackend.service.alarm.template;
 
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.service.AuctionService;
@@ -21,9 +21,9 @@ public abstract class AuctionAlarmTemplate {
                         () -> publishEvent(auction));
     }
 
-    abstract void update(Long targetId);
+    protected abstract void update(Long targetId);
 
-    abstract void publishEvent(Auction auction, Long bidMemberId);
+    protected abstract void publishEvent(Auction auction, Long bidMemberId);
 
-    abstract void publishEvent(Auction auction);
+    protected abstract void publishEvent(Auction auction);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/ChatAlarmTemplate.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/ChatAlarmTemplate.java
@@ -1,4 +1,4 @@
-package freshtrash.freshtrashbackend.service.alarm;
+package freshtrash.freshtrashbackend.service.alarm.template;
 
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.service.MemberService;
@@ -23,7 +23,7 @@ public abstract class ChatAlarmTemplate {
         publishEvent(update(targetMemberId), chatRoom.getProductId(), targetMemberId, currentMemberId);
     }
 
-    abstract int update(Long targetId);
+    protected abstract int update(Long targetId);
 
-    abstract void publishEvent(int updatedValue, Long productId, Long targetMemberId, Long currentMemberId);
+    protected abstract void publishEvent(int updatedValue, Long productId, Long targetMemberId, Long currentMemberId);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/ProductAlarmTemplate.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/ProductAlarmTemplate.java
@@ -1,4 +1,4 @@
-package freshtrash.freshtrashbackend.service.alarm;
+package freshtrash.freshtrashbackend.service.alarm.template;
 
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.service.ChatRoomService;
@@ -18,7 +18,7 @@ public abstract class ProductAlarmTemplate {
         publishEvent(chatRoom);
     }
 
-    abstract void update(ChatRoom chatRoom);
+    protected abstract void update(ChatRoom chatRoom);
 
-    abstract void publishEvent(ChatRoom chatRoom);
+    protected abstract void publishEvent(ChatRoom chatRoom);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
@@ -1,0 +1,40 @@
+package freshtrash.freshtrashbackend.service.producer;
+
+import freshtrash.freshtrashbackend.dto.events.AlarmEvent;
+import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.producer.publisher.MQPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static freshtrash.freshtrashbackend.config.rabbitmq.QueueType.AUCTION_BID_COMPLETE;
+import static freshtrash.freshtrashbackend.dto.constants.AlarmMessage.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuctionPublisher {
+    private final MQPublisher mqPublisher;
+
+    public void notCompleteBid(Auction auction) {
+        mqPublisher.publish(AlarmEvent.of(
+                AUCTION_BID_COMPLETE.getRoutingKey(),
+                AlarmPayload.ofAuctionNotBid(
+                        String.format(NOT_COMPLETE_AUCTION.getMessage(), auction.getTitle()), auction)));
+    }
+
+    public void completeBid(Auction auction, Long bidMemberId) {
+        mqPublisher.publish(AlarmEvent.of(
+                AUCTION_BID_COMPLETE.getRoutingKey(),
+                AlarmPayload.ofAuctionBidByBuyer(
+                        String.format(COMPLETE_BID_AUCTION.getMessage(), auction.getTitle()), auction, bidMemberId)));
+    }
+
+    public void requestPay(Auction auction, Long bidMemberId) {
+        mqPublisher.publish(AlarmEvent.of(
+                AUCTION_BID_COMPLETE.getRoutingKey(),
+                AlarmPayload.ofAuctionBidBySeller(
+                        String.format(REQUEST_PAY_AUCTION.getMessage(), auction.getTitle()), auction, bidMemberId)));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
@@ -21,7 +21,7 @@ public class AuctionPublisher {
         mqPublisher.publish(AlarmEvent.of(
                 AUCTION_BID_COMPLETE.getRoutingKey(),
                 AlarmPayload.ofAuctionNotBid(
-                        String.format(NOT_COMPLETE_AUCTION.getMessage(), auction.getTitle()), auction)));
+                        String.format(NOT_COMPLETED_AUCTION.getMessage(), auction.getTitle()), auction)));
     }
 
     public void completeBid(Auction auction, Long bidMemberId) {

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/ChatProducer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/ChatProducer.java
@@ -17,7 +17,7 @@ public class ChatProducer {
 
     public void occurredUserFlag(Long productId, Long targetMemberId, Long currentMemberId, String message) {
         log.debug(
-                "신고 알람 publish...\n\t=> productId: {}, targetMemberId: {}, currentMemberId: {}, message: {}",
+                "신고 알람 publish...\n\t=> targetId: {}, targetMemberId: {}, currentMemberId: {}, message: {}",
                 productId,
                 targetMemberId,
                 currentMemberId,

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -55,7 +55,7 @@ public class FixtureDto {
     public static AlarmPayload createAlarmPayload() {
         return AlarmPayload.builder()
                 .message("test message")
-                .productId(1L)
+                .targetId(1L)
                 .memberId(123L)
                 .fromMemberId(3L)
                 .alarmType(AlarmType.TRANSACTION)

--- a/src/test/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumerTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumerTest.java
@@ -52,7 +52,7 @@ class ProductAlarmConsumerTest {
         given(alarmService.saveAlarm(eq(alarmPayload))).willReturn(alarm);
         given(emitterRepository.findByMemberId(eq(memberId))).willReturn(Optional.of(sseEmitter));
         // whenxp
-        productAlarmConsumer.receiveProductDeal(channel, deliveryTag, alarmPayload);
+        productAlarmConsumer.consumeProductDealMessage(channel, deliveryTag, alarmPayload);
         ArgumentCaptor<AlarmPayload> alarmCaptor = ArgumentCaptor.forClass(AlarmPayload.class);
         // then
         verify(alarmService, times(1)).saveAlarm(alarmCaptor.capture());

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ProductReviewApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ProductReviewApiTest.java
@@ -51,7 +51,7 @@ class ProductReviewApiTest {
                         .content(objectMapper.writeValueAsString(reviewRequest)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.memberId").value(memberId))
-                .andExpect(jsonPath("$.productId").value(productId))
+                .andExpect(jsonPath("$.targetId").value(productId))
                 .andExpect(jsonPath("$.rating").value(reviewRequest.rate()));
         // then
     }

--- a/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
@@ -81,7 +81,7 @@ public class AuctionIntegrationTest {
         // 마감된 되었지만 status가 ONGOING인 경매 수
         int previousCount = auctionRepository.findAllEndedAuctions().size();
         // when
-        auctionEventService.completeAuction();
+        auctionEventService.processCompletedAuctions();
         // then
         assertThat(auctionRepository.findAllEndedAuctions().size()).isLessThan(previousCount);
     }

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionEventServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionEventServiceTest.java
@@ -13,7 +13,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -38,7 +37,7 @@ class AuctionEventServiceTest {
         given(auctionService.getEndedAuctions()).willReturn(List.of(auction));
         willDoNothing().given(completeBidAuctionAlarm).sendAlarm(auction);
         // when
-        auctionEventService.completeAuction();
+        auctionEventService.processCompletedAuctions();
         // then
         then(auctionService).should().getEndedAuctions();
         then(completeBidAuctionAlarm).should(times(1)).sendAlarm(auction);

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionEventServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionEventServiceTest.java
@@ -1,0 +1,46 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.alarm.CompleteBidAuctionAlarm;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class AuctionEventServiceTest {
+    @InjectMocks
+    private AuctionEventService auctionEventService;
+
+    @Mock
+    private AuctionService auctionService;
+
+    @Mock
+    private CompleteBidAuctionAlarm completeBidAuctionAlarm;
+
+    @DisplayName("경매 낙찰")
+    @Test
+    void given_endedAuctions_when_existsBidUser_then_closeAuctionAndSendAlarm() {
+        // given
+        Auction auction = Fixture.createAuction();
+        given(auctionService.getEndedAuctions()).willReturn(List.of(auction));
+        willDoNothing().given(completeBidAuctionAlarm).sendAlarm(auction);
+        // when
+        auctionEventService.completeAuction();
+        // then
+        then(auctionService).should().getEndedAuctions();
+        then(completeBidAuctionAlarm).should(times(1)).sendAlarm(auction);
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 특정 시간에 마감된 경매들을 확인하여 입찰 내역을 보고 낙찰 처리하도록 해야합니다. 이후 판매자 또는 구매자에게 관련 알림을 전송합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- Message Queue 추가
  - `queue.auction.complete` 이름으로 낙찰과 관련된 메시지를 처리하는 큐를 추가해주었습니다.
  - `queue.auction.complete.dlq`, `queue.auction.parking-lot` 이름으로 DLQ와 Parking Lot Queue를 추가해주었습니다.

- 매일 0시에 Schedule을 사용하여 마감된 경매의 낙찰을 처리하는 기능을 추가
  - `endedAt`이 현재 시간보다 이전이고 `AuctionStatus`가 ONGOING인 경매들을 모두 조회합니다.
  - 조회한 경매들의 `AuctionStatus`를 모두 CLOSE로 변경합니다.

  - 알림 전송
    - 입찰자가 있을 경우 판매자에게는 낙찰 알림을 전송하고 구매자에게는 결제 요청 알림을 전송합니다.
    - 입찰자가 없을 경우에는 판매자에게 입찰자가 없음을 알리는 알림을 전송합니다.

- 통합 테스트(`AuctionIntegrationTest -> completeAuction()`)를 작성하여 정상적으로 기능이 동작하는 것을 확인했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 마감된 경매 데이터를 하나 추가해주었습니다.
- AuctionEventService 클래스를 추가하여 경매에서 발생하는 이벤트를 처리하는 로직을 담당하도록 구현했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #172 
