### PR TITLE
경매가 취소된 경우 입찰자들에게 알림

### DIFF
--- a/database/mariadb/initdb.d/create_table.sql
+++ b/database/mariadb/initdb.d/create_table.sql
@@ -149,6 +149,7 @@ CREATE TABLE `auctions`
     `started_at`       datetime              NOT NULL,
     `ended_at`         datetime              NOT NULL,
     `created_at`       datetime              NOT NULL,
+    `deleted_at`       datetime,
     `version`          integer default 0     NOT NULL,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade
@@ -163,6 +164,7 @@ CREATE TABLE `bidding_history`
     `price`              integer               NOT NULL,
     `is_success_bidding` tinyint(1)            NOT NULL,
     `created_at`         datetime              NOT NULL,
+    `deleted_at`         datetime,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`auction_id`) references auctions (id) on delete cascade

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
@@ -40,6 +40,11 @@ public class BindingConfig {
         return createBinding(auctionCompleteQueue, topicExchange, AUCTION_BID_COMPLETE.getRoutingKey());
     }
 
+    @Bean
+    Binding cancelAuctionBinding(Queue cancelAuctionQueue, TopicExchange topicExchange) {
+        return createBinding(cancelAuctionQueue, topicExchange, CANCEL_AUCTION.getRoutingKey());
+    }
+
     /**
      * DLQ Binding
      */
@@ -66,6 +71,11 @@ public class BindingConfig {
     @Bean
     Binding dlqAuctionCompleteBinding(Queue dlqAuctionCompleteQueue, TopicExchange dlqExchange) {
         return createBinding(dlqAuctionCompleteQueue, dlqExchange, DLQ_AUCTION_BID_COMPLETE.getRoutingKey());
+    }
+
+    @Bean
+    Binding dlqCancelAuctionBinding(Queue dlqCancelAuctionQueue, TopicExchange dlqExchange) {
+        return createBinding(dlqCancelAuctionQueue, dlqExchange, DLQ_CANCEL_AUCTION.getRoutingKey());
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
@@ -43,6 +43,11 @@ public class QueueConfig {
         return createQueueWithDLQ(AUCTION_BID_COMPLETE, DLQ_AUCTION_BID_COMPLETE);
     }
 
+    @Bean
+    Queue cancelAuctionQueue() {
+        return createQueueWithDLQ(CANCEL_AUCTION, DLQ_CANCEL_AUCTION);
+    }
+
     /**
      * DLQ
      */
@@ -69,6 +74,11 @@ public class QueueConfig {
     @Bean
     Queue dlqAuctionCompleteQueue() {
         return createQueue(DLQ_AUCTION_BID_COMPLETE);
+    }
+
+    @Bean
+    Queue dlqCancelAuctionQueue() {
+        return createQueue(DLQ_CANCEL_AUCTION);
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
@@ -12,6 +12,7 @@ public enum QueueType {
     PRODUCT_TRANSACTION_FLAG("queue.product.flag", "product.productDeal.flag"),
     CHAT("queue.chat", "chats.#"),
     AUCTION_BID_COMPLETE("queue.auction.complete", "auction.bid.complete"),
+    CANCEL_AUCTION("queue.auction.cancel", "auction.cancel"),
 
     // DLQ
     DLQ_PRODUCT_TRANSACTION_COMPLETE("queue.product.complete.dlq", "product.productDeal.complete"),
@@ -19,6 +20,7 @@ public enum QueueType {
     DLQ_PRODUCT_TRANSACTION_FLAG("queue.product.flag.dlq", "product.productDeal.flag"),
     DLQ_CHAT("queue.chat.dlq", "chats.#"),
     DLQ_AUCTION_BID_COMPLETE("queue.auction.complete.dlq", "auction.bid.complete"),
+    DLQ_CANCEL_AUCTION("queue.auction.cancel.dlq", "auction.cancel"),
 
     // Parking Lot
     PRODUCT_PARKING_LOT("queue.product.parking-lot", "product.#"),

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/AuctionAlarmConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/AuctionAlarmConsumer.java
@@ -24,7 +24,7 @@ public class AuctionAlarmConsumer {
      * 경매 알람 메시지 전송 Listener
      */
     @ManualAcknowledge
-    @RabbitListener(queues = {"#{auctionCompleteQueue.name}"})
+    @RabbitListener(queues = {"#{auctionCompleteQueue.name}", "#{cancelAuctionQueue.name}"})
     public void consumeAuctionMessage(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload AlarmPayload alarmPayload) {
         log.debug("receive complete bid auction message: {}", alarmPayload);

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
@@ -25,7 +25,8 @@ public class DeadLetterConsumer {
                 "#{dlqProductFlagQueue.name}",
                 "#{dlqProductChangeStatusQueue.name}",
                 "#{dlqChatQueue.name}",
-                "#{dlqAuctionCompleteQueue.name}"
+                "#{dlqAuctionCompleteQueue.name}",
+                "#{dlqCancelAuctionQueue.name}"
             })
     public void handleFailedProductDealMessage(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, Message message) {

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
@@ -6,6 +6,7 @@ import freshtrash.freshtrashbackend.dto.request.BiddingRequest;
 import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.AuctionEventService;
 import freshtrash.freshtrashbackend.service.AuctionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,6 +28,7 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 @RequestMapping("/api/v1/auctions")
 public class AuctionApi {
     private final AuctionService auctionService;
+    private final AuctionEventService auctionEventService;
 
     @GetMapping
     public ResponseEntity<Page<AuctionResponse>> getAuctions(
@@ -52,9 +54,9 @@ public class AuctionApi {
     }
 
     @DeleteMapping("/{auctionId}")
-    public ResponseEntity<Void> deleteAuction(
+    public ResponseEntity<Void> cancelAuction(
             @PathVariable Long auctionId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        auctionService.deleteAuction(auctionId, memberPrincipal.getUserRole(), memberPrincipal.id());
+        auctionEventService.cancelAuction(auctionId, memberPrincipal.getUserRole(), memberPrincipal.id());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
@@ -12,8 +12,10 @@ public enum AlarmMessage {
     UPDATED_ONGOING_MESSAGE("%s님이 판매중으로 판매상태를 변경하였습니다."),
     FLAG_MESSAGE("%d번 신고받은 내역이 있습니다. 신고받은 횟수가 10번이상 되면 서비스를 이용하실 수 없습니다."),
     EXCEED_FLAG_MESSAGE("10번이상 신고받으셔서 더이상 서비스를 이용하실 수 없습니다."),
-    NOT_COMPLETED_AUCTION("겅매 [%s]가 입찰된 내역이 없습니다."),
-    COMPLETE_BID_AUCTION("경매 [%s]가 낙찰되었습니다."),
-    REQUEST_PAY_AUCTION("경매 [%s]가 낙찰되었습니다. 24시간 이내에 결제바랍니다.");
+    NOT_COMPLETED_AUCTION_MESSAGE("겅매 [%s]가 입찰된 내역이 없습니다."),
+    COMPLETE_BID_AUCTION_MESSAGE("경매 [%s]가 낙찰되었습니다."),
+    REQUEST_PAY_AUCTION_MESSAGE("경매 [%s]가 낙찰되었습니다. 24시간 이내에 결제바랍니다."),
+    CANCEL_AUCTION_MESSAGE("경매 [%s]가 취소되었습니다.");
+
     private final String message;
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AlarmPayload.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AlarmPayload.java
@@ -81,6 +81,25 @@ public record AlarmPayload(String message, Long targetId, Long memberId, Long fr
                 .build();
     }
 
+    /**
+     * 경매가 취소되었음을 입찰자들에게 알림
+     */
+    public static AlarmPayload ofCancelAuction(String message, Auction auction, Long fromMemberId) {
+        return ofAuctionBid(message, auction, AlarmType.CANCEL)
+                .memberId(fromMemberId)
+                .fromMemberId(auction.getMemberId())
+                .build();
+    }
+
+    /**
+     * 경매가 취소되었음을 판매자에게 알림
+     */
+    public static AlarmPayload ofCancelAuction(String message, Auction auction) {
+        return ofAuctionBid(message, auction, AlarmType.CANCEL)
+                .memberId(auction.getMemberId())
+                .build();
+    }
+
     private static AlarmPayloadBuilder ofProductDeal(String message, ChatRoom chatRoom, AlarmType alarmType) {
         return AlarmPayload.builder()
                 .message(message)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Auction.java
@@ -6,6 +6,8 @@ import freshtrash.freshtrashbackend.entity.constants.AuctionStatus;
 import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
 import freshtrash.freshtrashbackend.entity.constants.ProductStatus;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -20,6 +22,8 @@ import static javax.persistence.FetchType.LAZY;
 @ToString(callSuper = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "update auctions set deleted_at = current_timestamp where id=?")
+@Where(clause = "deleted_at is NULL")
 public class Auction extends CreatedAt {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -75,6 +79,8 @@ public class Auction extends CreatedAt {
     @OrderBy("createdAt DESC")
     @OneToMany(mappedBy = "auction", cascade = CascadeType.ALL, fetch = LAZY)
     private Set<BiddingHistory> biddingHistories = new LinkedHashSet<>();
+
+    private LocalDateTime deletedAt;
 
     @Version
     private int version;

--- a/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
@@ -2,8 +2,11 @@ package freshtrash.freshtrashbackend.entity;
 
 import freshtrash.freshtrashbackend.entity.audit.CreatedAt;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 import static javax.persistence.FetchType.LAZY;
 
@@ -13,6 +16,8 @@ import static javax.persistence.FetchType.LAZY;
 @Table(name = "bidding_history")
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "update bidding_history set deleted_at = current_timestamp where id=?")
+@Where(clause = "deleted_at is NULL")
 public class BiddingHistory extends CreatedAt {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,6 +45,8 @@ public class BiddingHistory extends CreatedAt {
 
     @Column(nullable = false)
     private Long auctionId;
+
+    private LocalDateTime deletedAt;
 
     @Builder
     public BiddingHistory(int price, Long memberId, Long auctionId) {

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
@@ -5,6 +5,7 @@ public enum AlarmType {
     TRANSACTION, // 거래 상태 변경 시 알림
     BOOKING_REQUEST, // 예약 요청 알림
     BIDDING, // 낙찰 알림
+    CANCEL, // 경매 취소 알림
     PAY, // 결제 완료 알림
     RECEIVE, // 상품 수령 알림
     NOT_PAY, // 미결제 알림

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AlarmRepository.java
@@ -14,7 +14,9 @@ import java.time.LocalDateTime;
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Page<Alarm> findAllByMember_Id(Long memberId, Pageable pageable);
 
-    @Query(nativeQuery = true, value = "update alarms a set a.read_at = current_timestamp where a.id = ?1 and a.read_at is null")
+    @Query(
+            nativeQuery = true,
+            value = "update alarms a set a.read_at = current_timestamp where a.id = ?1 and a.read_at is null")
     void updateReadAtById(Long alarmId);
 
     boolean existsByIdAndMember_Id(Long alarmId, Long memberId);

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
@@ -36,6 +36,9 @@ public interface AuctionRepository
     @EntityGraph(attributePaths = "member")
     Optional<Auction> findById(Long auctionId);
 
+    @EntityGraph(attributePaths = {"member", "biddingHistories"})
+    Optional<Auction> findWithBiddingHistoryById(Long auctionId);
+
     boolean existsByIdAndMemberId(Long auctionId, Long memberId);
 
     @EntityGraph(attributePaths = "biddingHistories")

--- a/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
@@ -5,5 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Transactional(propagation = Propagation.SUPPORTS)
-public interface BiddingHistoryRepository extends JpaRepository<BiddingHistory, Long> {}
+public interface BiddingHistoryRepository extends JpaRepository<BiddingHistory, Long> {
+    List<BiddingHistory> findAllByAuctionId(Long auctionId);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/ChatRoomRepository.java
@@ -2,7 +2,6 @@ package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.entity.constants.SellStatus;
-import freshtrash.freshtrashbackend.repository.projections.BuyerIdSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;

--- a/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/MemberRepository.java
@@ -1,7 +1,6 @@
 package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.Member;
-import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.repository.projections.FileNameSummary;
 import freshtrash.freshtrashbackend.repository.projections.FlagCountSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,13 +24,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
 
-    @Query(nativeQuery = true, value = """
-            update members m 
-            set m.flag_count = m.flag_count + 1, 
-                m.user_role = case 
-                    when m.flag_count >= ?2 then 'BLACK_USER' 
-                    else m.user_role 
-                end 
+    @Query(
+            nativeQuery = true,
+            value =
+                    """
+            update members m
+            set m.flag_count = m.flag_count + 1,
+                m.user_role = case
+                    when m.flag_count >= ?2 then 'BLACK_USER'
+                    else m.user_role
+                end
             where m.id = ?1
             """)
     void updateFlagCount(Long memberId, int flagLimit);

--- a/src/main/java/freshtrash/freshtrashbackend/repository/custom/CustomProductRepositoryImpl.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/custom/CustomProductRepositoryImpl.java
@@ -30,12 +30,18 @@ public class CustomProductRepositoryImpl implements CustomProductRepository {
         if (StringUtils.hasText(district)) {
             predicate = Expressions.booleanTemplate(
                             "JSON_CONTAINS({0}, {1}, {2})",
-                            QProduct.product.address, Expressions.stringTemplate("JSON_QUOTE({0})", district), "$.district")
+                            QProduct.product.address,
+                            Expressions.stringTemplate("JSON_QUOTE({0})", district),
+                            "$.district")
                     .isTrue()
                     .or(predicate);
         }
         QProduct product = QProduct.product;
-        Long totalOfElements = jpaQueryFactory.select(product.count()).from(product).where(predicate).fetchFirst();
+        Long totalOfElements = jpaQueryFactory
+                .select(product.count())
+                .from(product)
+                .where(predicate)
+                .fetchFirst();
         List<Product> products = jpaQueryFactory
                 .selectFrom(product)
                 .where(predicate)

--- a/src/main/java/freshtrash/freshtrashbackend/repository/projections/FileNameSummary.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/projections/FileNameSummary.java
@@ -1,4 +1,3 @@
 package freshtrash.freshtrashbackend.repository.projections;
 
-public record FileNameSummary(String fileName) {
-}
+public record FileNameSummary(String fileName) {}

--- a/src/main/java/freshtrash/freshtrashbackend/service/ProductDealService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/ProductDealService.java
@@ -20,7 +20,8 @@ public class ProductDealService {
     private final ProductRepository productRepository;
     private final ChatRoomRepository chatRoomRepository;
 
-    public Page<ProductResponse> getTransactedProducts(Long memberId, ProductDealMemberType memberType, Pageable pageable) {
+    public Page<ProductResponse> getTransactedProducts(
+            Long memberId, ProductDealMemberType memberType, Pageable pageable) {
         switch (memberType) {
             case SELLER_CLOSE -> {
                 return productDealLogRepository
@@ -47,7 +48,8 @@ public class ProductDealService {
      * - 거래 내역 저장
      */
     @Transactional
-    public void completeProductDeal(Long productId, Long chatRoomId, Long sellerId, Long buyerId, SellStatus sellStatus) {
+    public void completeProductDeal(
+            Long productId, Long chatRoomId, Long sellerId, Long buyerId, SellStatus sellStatus) {
         updateSellStatus(productId, chatRoomId, sellStatus);
         saveProductDealLog(productId, sellerId, buyerId);
     }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelAuctionAlarm.java
@@ -1,0 +1,35 @@
+package freshtrash.freshtrashbackend.service.alarm;
+
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.service.AuctionService;
+import freshtrash.freshtrashbackend.service.alarm.template.AuctionAlarmTemplate;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CancelAuctionAlarm extends AuctionAlarmTemplate {
+
+    public CancelAuctionAlarm(AuctionService auctionService, AuctionPublisher producer) {
+        super(auctionService, producer);
+    }
+
+    @Override
+    protected void update(Long targetId) {
+        log.debug("경매 취소(삭제) 처리");
+        this.auctionService.deleteAuction(targetId);
+    }
+
+    @Override
+    protected void publishEvent(Auction auction, Long bidMemberId) {
+        log.debug("입찰자에게 경매 취소되었음을 알림");
+        this.producer.cancelAuction(auction, bidMemberId);
+    }
+
+    @Override
+    protected void publishEvent(Auction auction) {
+        log.debug("구매자에게 경매 취소되었음을 알림");
+        this.producer.cancelAuction(auction);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import static freshtrash.freshtrashbackend.config.rabbitmq.QueueType.AUCTION_BID_COMPLETE;
+import static freshtrash.freshtrashbackend.config.rabbitmq.QueueType.CANCEL_AUCTION;
 import static freshtrash.freshtrashbackend.dto.constants.AlarmMessage.*;
 
 @Slf4j
@@ -21,20 +22,38 @@ public class AuctionPublisher {
         mqPublisher.publish(AlarmEvent.of(
                 AUCTION_BID_COMPLETE.getRoutingKey(),
                 AlarmPayload.ofAuctionNotBid(
-                        String.format(NOT_COMPLETED_AUCTION.getMessage(), auction.getTitle()), auction)));
+                        String.format(NOT_COMPLETED_AUCTION_MESSAGE.getMessage(), auction.getTitle()), auction)));
     }
 
     public void completeBid(Auction auction, Long bidMemberId) {
         mqPublisher.publish(AlarmEvent.of(
                 AUCTION_BID_COMPLETE.getRoutingKey(),
                 AlarmPayload.ofAuctionBidByBuyer(
-                        String.format(COMPLETE_BID_AUCTION.getMessage(), auction.getTitle()), auction, bidMemberId)));
+                        String.format(COMPLETE_BID_AUCTION_MESSAGE.getMessage(), auction.getTitle()),
+                        auction,
+                        bidMemberId)));
     }
 
     public void requestPay(Auction auction, Long bidMemberId) {
         mqPublisher.publish(AlarmEvent.of(
                 AUCTION_BID_COMPLETE.getRoutingKey(),
                 AlarmPayload.ofAuctionBidBySeller(
-                        String.format(REQUEST_PAY_AUCTION.getMessage(), auction.getTitle()), auction, bidMemberId)));
+                        String.format(REQUEST_PAY_AUCTION_MESSAGE.getMessage(), auction.getTitle()),
+                        auction,
+                        bidMemberId)));
+    }
+
+    public void cancelAuction(Auction auction, Long bidMemberId) {
+        mqPublisher.publish(AlarmEvent.of(
+                CANCEL_AUCTION.getRoutingKey(),
+                AlarmPayload.ofCancelAuction(
+                        String.format(CANCEL_AUCTION_MESSAGE.getMessage(), auction.getTitle()), auction, bidMemberId)));
+    }
+
+    public void cancelAuction(Auction auction) {
+        mqPublisher.publish(AlarmEvent.of(
+                CANCEL_AUCTION.getRoutingKey(),
+                AlarmPayload.ofCancelAuction(
+                        String.format(CANCEL_AUCTION_MESSAGE.getMessage(), auction.getTitle()), auction)));
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AuctionApiTest.java
@@ -11,6 +11,7 @@ import freshtrash.freshtrashbackend.dto.response.AuctionResponse;
 import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
+import freshtrash.freshtrashbackend.service.AuctionEventService;
 import freshtrash.freshtrashbackend.service.AuctionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,6 +52,9 @@ class AuctionApiTest {
 
     @MockBean
     private AuctionService auctionService;
+
+    @MockBean
+    private AuctionEventService auctionEventService;
 
     @DisplayName("경매 추가 요청")
     @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
@@ -114,7 +118,7 @@ class AuctionApiTest {
         // given
         Long auctionId = 1L, memberId = 123L;
         UserRole userRole = UserRole.USER;
-        willDoNothing().given(auctionService).deleteAuction(auctionId, userRole, memberId);
+        willDoNothing().given(auctionEventService).cancelAuction(auctionId, userRole, memberId);
         // when
         mvc.perform(delete("/api/v1/auctions/" + auctionId)).andExpect(status().isNoContent());
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/integration/AuctionIntegrationTest.java
@@ -4,6 +4,8 @@ import freshtrash.freshtrashbackend.Fixture.FixtureDto;
 import freshtrash.freshtrashbackend.config.TestSecurityConfig;
 import freshtrash.freshtrashbackend.controller.AuctionApi;
 import freshtrash.freshtrashbackend.dto.request.BiddingRequest;
+import freshtrash.freshtrashbackend.entity.constants.UserRole;
+import freshtrash.freshtrashbackend.exception.AuctionException;
 import freshtrash.freshtrashbackend.repository.AuctionRepository;
 import freshtrash.freshtrashbackend.service.AuctionEventService;
 import freshtrash.freshtrashbackend.service.AuctionService;
@@ -24,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @Disabled
@@ -84,5 +87,17 @@ public class AuctionIntegrationTest {
         auctionEventService.processCompletedAuctions();
         // then
         assertThat(auctionRepository.findAllEndedAuctions().size()).isLessThan(previousCount);
+    }
+
+    @Test
+    @DisplayName("경매 취소 후 입찰자들에게 알람 전송")
+    void cancelAuction() {
+        // given
+        Long auctionId = 1L, memberId = 1L;
+        UserRole userRole = UserRole.USER;
+        // when
+        auctionEventService.cancelAuction(auctionId, userRole, memberId);
+        // then
+        assertThatThrownBy(() -> auctionService.getAuction(auctionId)).isInstanceOf(AuctionException.class);
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
@@ -99,20 +99,6 @@ class AuctionServiceTest {
         assertThat(auction.getId()).isEqualTo(expectedAuction.getId());
     }
 
-    @DisplayName("경매 삭제")
-    @Test
-    void given_auctionId_when_then_deleteAuction() {
-        // given
-        Long auctionId = 1L, memberId = 123L;
-        UserRole userRole = UserRole.USER;
-        given(auctionRepository.existsByIdAndMemberId(eq(auctionId), eq(memberId)))
-                .willReturn(true);
-        willDoNothing().given(auctionRepository).deleteById(auctionId);
-        // when
-        auctionService.deleteAuction(auctionId, userRole, memberId);
-        // then
-    }
-
     @DisplayName("경매 입찰")
     @Test
     void given_auctionIdAndBiddingPriceAndMemberId_when_passedDefenseLogic_then_updatePriceAndAddHistory() {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

- 판매자가 경매를 갑자기 취소해버릴 경우 입찰했던 사용자들에게 취소되었음을 알려야합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- 경매 취소 메시지를 전달하기위한 Queue 추가
  - `queue.auction.cancel`, `queue.auction.cancel.dlq` 추가

- 경매 취소 메시지를 전송하는 로직을 수행하는 클래스 추가
  - `CancelAuctionAlarm`에서 경매를 삭제하고 입찰한 사용자들에게 알림 메시지를 전송합니다.
  - 또한 구매자에게도 경매가 취소되었음을 알리는 알람을 전송합니다.
  
- consumer의 listener에 추가한 queue를 추가해주었습니다.

- 테스트 코드 작성
  - 단위 테스트와 통합 테스트를 통해 정상적으로 동작했음을 확인했습니다. (추후 테스트 코드 개선할 예정)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- Auction, BiddingHistory 삭제 시 soft delete 적용
  - 각 엔티티에 deleted_at 속성 추가

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #174 
