### PR TITLE
경매 낙찰 상품 결제 완료 후 처리

### DIFF
--- a/database/mariadb/initdb.d/create_table.sql
+++ b/database/mariadb/initdb.d/create_table.sql
@@ -158,13 +158,13 @@ CREATE TABLE `auctions`
 
 CREATE TABLE `bidding_history`
 (
-    `id`                 bigint AUTO_INCREMENT NOT NULL,
-    `member_id`          bigint                NOT NULL,
-    `auction_id`         bigint                NOT NULL,
-    `price`              integer               NOT NULL,
-    `is_success_bidding` tinyint(1)            NOT NULL,
-    `created_at`         datetime              NOT NULL,
-    `deleted_at`         datetime,
+    `id`         bigint AUTO_INCREMENT NOT NULL,
+    `member_id`  bigint                NOT NULL,
+    `auction_id` bigint                NOT NULL,
+    `price`      integer               NOT NULL,
+    `is_pay`     tinyint(1)            NOT NULL,
+    `created_at` datetime              NOT NULL,
+    `deleted_at` datetime,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`auction_id`) references auctions (id) on delete cascade

--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -190,7 +190,8 @@ values (1, 'test.png', 'title', 'content', 'CLOTHING', 'GOOD', 'ONGOING', 1000, 
         date_add(now(), interval 1 hour), now()),
        (4, 'test.png', 'title4', 'content4', 'SPORTS', 'GOOD', 'ONGOING', 3000, 5, now(), now(), now());
 
-insert into bidding_history(member_id, auction_id, price, is_success_bidding, created_at)
+insert into bidding_history(member_id, auction_id, price, is_pay, created_at)
 values (2, 1, 1000, true, now()),
        (1, 2, 1000, false, now()),
+       (1, 2, 2000, false, now()),
        (1, 3, 3000, true, now());

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
@@ -45,6 +45,11 @@ public class BindingConfig {
         return createBinding(cancelAuctionQueue, topicExchange, CANCEL_AUCTION.getRoutingKey());
     }
 
+    @Bean
+    Binding auctionPayBinding(Queue auctionPayQueue, TopicExchange topicExchange) {
+        return createBinding(auctionPayQueue, topicExchange, AUCTION_PAY.getRoutingKey());
+    }
+
     /**
      * DLQ Binding
      */
@@ -76,6 +81,11 @@ public class BindingConfig {
     @Bean
     Binding dlqCancelAuctionBinding(Queue dlqCancelAuctionQueue, TopicExchange dlqExchange) {
         return createBinding(dlqCancelAuctionQueue, dlqExchange, DLQ_CANCEL_AUCTION.getRoutingKey());
+    }
+
+    @Bean
+    Binding dlqAuctionPayBinding(Queue dlqAuctionPayQueue, TopicExchange dlqExchange) {
+        return createBinding(dlqAuctionPayQueue, dlqExchange, DLQ_AUCTION_PAY.getRoutingKey());
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
@@ -48,6 +48,11 @@ public class QueueConfig {
         return createQueueWithDLQ(CANCEL_AUCTION, DLQ_CANCEL_AUCTION);
     }
 
+    @Bean
+    Queue auctionPayQueue() {
+        return createQueueWithDLQ(AUCTION_PAY, DLQ_AUCTION_PAY);
+    }
+
     /**
      * DLQ
      */
@@ -79,6 +84,11 @@ public class QueueConfig {
     @Bean
     Queue dlqCancelAuctionQueue() {
         return createQueue(DLQ_CANCEL_AUCTION);
+    }
+
+    @Bean
+    Queue dlqAuctionPayQueue() {
+        return createQueue(DLQ_AUCTION_PAY);
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
@@ -13,6 +13,7 @@ public enum QueueType {
     CHAT("queue.chat", "chats.#"),
     AUCTION_BID_COMPLETE("queue.auction.complete", "auction.bid.complete"),
     CANCEL_AUCTION("queue.auction.cancel", "auction.cancel"),
+    AUCTION_PAY("queue.auction.pay", "auction.pay"),
 
     // DLQ
     DLQ_PRODUCT_TRANSACTION_COMPLETE("queue.product.complete.dlq", "product.productDeal.complete"),
@@ -21,6 +22,7 @@ public enum QueueType {
     DLQ_CHAT("queue.chat.dlq", "chats.#"),
     DLQ_AUCTION_BID_COMPLETE("queue.auction.complete.dlq", "auction.bid.complete"),
     DLQ_CANCEL_AUCTION("queue.auction.cancel.dlq", "auction.cancel"),
+    DLQ_AUCTION_PAY("queue.auction.pay.dlq", "auction.pay"),
 
     // Parking Lot
     PRODUCT_PARKING_LOT("queue.product.parking-lot", "product.#"),

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/AuctionAlarmConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/AuctionAlarmConsumer.java
@@ -2,7 +2,7 @@ package freshtrash.freshtrashbackend.consumer;
 
 import com.rabbitmq.client.Channel;
 import freshtrash.freshtrashbackend.aspect.annotation.ManualAcknowledge;
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
 import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.service.AlarmService;
@@ -24,11 +24,11 @@ public class AuctionAlarmConsumer {
      * 경매 알람 메시지 전송 Listener
      */
     @ManualAcknowledge
-    @RabbitListener(queues = {"#{auctionCompleteQueue.name}", "#{cancelAuctionQueue.name}"})
+    @RabbitListener(queues = {"#{auctionCompleteQueue.name}", "#{cancelAuctionQueue.name}", "#{auctionPayQueue.name}"})
     public void consumeAuctionMessage(
-            Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload AlarmPayload alarmPayload) {
+            Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload BaseAlarmPayload alarmPayload) {
         log.debug("receive complete bid auction message: {}", alarmPayload);
         Alarm alarm = alarmService.saveAlarm(alarmPayload);
-        alarmService.receive(alarmPayload.memberId(), AlarmResponse.fromEntity(alarm));
+        alarmService.receive(alarmPayload.getMemberId(), AlarmResponse.fromEntity(alarm));
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
@@ -26,7 +26,8 @@ public class DeadLetterConsumer {
                 "#{dlqProductChangeStatusQueue.name}",
                 "#{dlqChatQueue.name}",
                 "#{dlqAuctionCompleteQueue.name}",
-                "#{dlqCancelAuctionQueue.name}"
+                "#{dlqCancelAuctionQueue.name}",
+                "#{dlqAuctionPayQueue}"
             })
     public void handleFailedProductDealMessage(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, Message message) {

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/ParkingLotConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/ParkingLotConsumer.java
@@ -2,7 +2,7 @@ package freshtrash.freshtrashbackend.consumer;
 
 import com.rabbitmq.client.Channel;
 import freshtrash.freshtrashbackend.aspect.annotation.ManualAcknowledge;
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
 import freshtrash.freshtrashbackend.service.SlackService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,16 +19,16 @@ public class ParkingLotConsumer {
     private final SlackService slackService;
 
     /**
-     * Product Parking Lot Listener
+     * Parking Lot Listener
      */
     @ManualAcknowledge
     @RabbitListener(
             queues = {"#{productParkingLotQueue.name}", "#{chatParkingLotQueue.name}", "#{auctionParkingLotQueue.name}"
             })
     public void handleProductParkingLot(
-            Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload AlarmPayload alarmPayload) {
+            Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload BaseAlarmPayload alarmPayload) {
         log.warn("consume from parking lot");
-        slackService.sendMessage(alarmPayload.message(), alarmPayload.toMap());
+        slackService.sendMessage(alarmPayload.getMessage(), alarmPayload.toMap());
         log.debug("send notification to slack");
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumer.java
@@ -2,7 +2,7 @@ package freshtrash.freshtrashbackend.consumer;
 
 import com.rabbitmq.client.Channel;
 import freshtrash.freshtrashbackend.aspect.annotation.ManualAcknowledge;
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
 import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.service.AlarmService;
@@ -27,9 +27,9 @@ public class ProductAlarmConsumer {
     @RabbitListener(
             queues = {"#{productCompleteQueue.name}", "#{productFlagQueue.name}", "#{productChangeStatusQueue.name}"})
     public void consumeProductDealMessage(
-            Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload AlarmPayload alarmPayload) {
+            Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload BaseAlarmPayload alarmPayload) {
         log.debug("receive complete productDeal message: {}", alarmPayload);
         Alarm alarm = alarmService.saveAlarm(alarmPayload);
-        alarmService.receive(alarmPayload.memberId(), AlarmResponse.fromEntity(alarm));
+        alarmService.receive(alarmPayload.getMemberId(), AlarmResponse.fromEntity(alarm));
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionApi.java
@@ -8,6 +8,7 @@ import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.service.AuctionEventService;
 import freshtrash.freshtrashbackend.service.AuctionService;
+import freshtrash.freshtrashbackend.service.BiddingHistoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +30,7 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 public class AuctionApi {
     private final AuctionService auctionService;
     private final AuctionEventService auctionEventService;
+    private final BiddingHistoryService biddingHistoryService;
 
     @GetMapping
     public ResponseEntity<Page<AuctionResponse>> getAuctions(
@@ -66,6 +68,13 @@ public class AuctionApi {
             @RequestBody @Valid BiddingRequest biddingRequest,
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         auctionService.requestBidding(auctionId, biddingRequest.biddingPrice(), memberPrincipal.id());
+        return ResponseEntity.ok(null);
+    }
+
+    @PutMapping("/{auctionId}/pay")
+    public ResponseEntity<Void> completePay(
+            @PathVariable Long auctionId, @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        biddingHistoryService.updateToCompletedPayAndNotify(auctionId, memberPrincipal.id());
         return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
@@ -15,7 +15,9 @@ public enum AlarmMessage {
     NOT_COMPLETED_AUCTION_MESSAGE("겅매 [%s]가 입찰된 내역이 없습니다."),
     COMPLETE_BID_AUCTION_MESSAGE("경매 [%s]가 낙찰되었습니다."),
     REQUEST_PAY_AUCTION_MESSAGE("경매 [%s]가 낙찰되었습니다. 24시간 이내에 결제바랍니다."),
-    CANCEL_AUCTION_MESSAGE("경매 [%s]가 취소되었습니다.");
+    CANCEL_AUCTION_MESSAGE("경매 [%s]가 취소되었습니다."),
+    COMPLETED_PAY_MESSAGE("경매 [%s] 상품 결제가 완료되었습니다."),
+    COMPLETED_PAY_AND_REQUEST_DELIVERY_MESSAGE("경매 [%s] 상품 결제가 완료되었습니다. %s 님에게 상품을 배송해주세요.");
 
     private final String message;
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/events/AlarmEvent.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/events/AlarmEvent.java
@@ -1,16 +1,16 @@
 package freshtrash.freshtrashbackend.dto.events;
 
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AlarmEvent extends BaseEvent<AlarmPayload> {
-    public AlarmEvent(String routingKey, AlarmPayload payload) {
+public class AlarmEvent extends BaseEvent<BaseAlarmPayload> {
+    public AlarmEvent(String routingKey, BaseAlarmPayload payload) {
         super(routingKey, payload);
     }
 
-    public static AlarmEvent of(String routingKey, AlarmPayload payload) {
+    public static AlarmEvent of(String routingKey, BaseAlarmPayload payload) {
         return new AlarmEvent(routingKey, payload);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionAlarmPayload.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionAlarmPayload.java
@@ -1,0 +1,109 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.constants.AlarmType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuctionAlarmPayload extends BaseAlarmPayload {
+
+    @Override
+    public Map<String, String> toMap() {
+        Map<String, String> data = new HashMap<>();
+        data.put("auctionId", targetId.toString());
+        data.put("memberId", memberId.toString());
+        data.put("fromMemberId", fromMemberId.toString());
+        data.put("alarmType", alarmType.name());
+        return data;
+    }
+
+    /**
+     * 경매가 입찰되지 않았음을 알림
+     */
+    public static BaseAlarmPayload ofNotExistBidders(String message, Auction auction) {
+        return ofAuction(message, auction, AlarmType.BIDDING)
+                .memberId(auction.getMemberId())
+                .build();
+    }
+
+    /**
+     * 경매가 낙찰되었음을 판매자에게 알림
+     */
+    public static BaseAlarmPayload ofCompletedAuction(String message, Auction auction, Long fromMemberId) {
+        return ofAuction(message, auction, AlarmType.BIDDING)
+                .memberId(auction.getMemberId())
+                .fromMemberId(fromMemberId)
+                .build();
+    }
+
+    /**
+     * 경매가 낙찰되어 결제 요청을 구매자에게 알림
+     */
+    public static BaseAlarmPayload ofRequestPay(String message, Auction auction, Long fromMemberId) {
+        return ofAuction(message, auction, AlarmType.BIDDING)
+                .memberId(fromMemberId)
+                .fromMemberId(auction.getMemberId())
+                .build();
+    }
+
+    /**
+     * 경매가 취소되었음을 입찰자들에게 알림
+     */
+    public static BaseAlarmPayload ofCancelAuctionToBidders(String message, Auction auction, Long fromMemberId) {
+        return ofAuction(message, auction, AlarmType.CANCEL)
+                .memberId(fromMemberId)
+                .fromMemberId(auction.getMemberId())
+                .build();
+    }
+
+    /**
+     * 경매가 취소되었음을 판매자에게 알림
+     */
+    public static BaseAlarmPayload ofCancelAuctionToSeller(String message, Auction auction) {
+        return ofAuction(message, auction, AlarmType.CANCEL)
+                .memberId(auction.getMemberId())
+                .build();
+    }
+
+    /**
+     * 결제 완료되었음을 낙찰자(결제자)에게 알림
+     */
+    public static BaseAlarmPayload ofCompletedPayToWonBidder(String message, Auction auction, Long payMemberId) {
+        return ofAuction(message, auction, AlarmType.PAY)
+                .memberId(payMemberId)
+                .fromMemberId(auction.getMemberId())
+                .build();
+    }
+
+    /**
+     * 결제 완료되었음을 판매자에게 알리고 구매자에게 배송 요청
+     */
+    public static BaseAlarmPayload ofCompletedPayAndRequestDeliveryToSeller(
+            String message, Auction auction, Long payMemberId) {
+        return ofAuction(message, auction, AlarmType.PAY)
+                .memberId(auction.getMemberId())
+                .fromMemberId(payMemberId)
+                .build();
+    }
+
+    private static AuctionAlarmPayloadBuilder ofAuction(String message, Auction auction, AlarmType alarmType) {
+        return AuctionAlarmPayload.builder()
+                .message(message)
+                .targetId(auction.getId())
+                .alarmType(alarmType);
+    }
+
+    @Builder
+    public AuctionAlarmPayload(String message, Long targetId, Long memberId, Long fromMemberId, AlarmType alarmType) {
+        this.message = message;
+        this.targetId = targetId;
+        this.memberId = memberId;
+        this.fromMemberId = fromMemberId;
+        this.alarmType = alarmType;
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/BaseAlarmPayload.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/BaseAlarmPayload.java
@@ -1,0 +1,19 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+import freshtrash.freshtrashbackend.entity.constants.AlarmType;
+import lombok.Getter;
+
+import javax.persistence.MappedSuperclass;
+import java.util.Map;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseAlarmPayload {
+    protected String message;
+    protected Long targetId;
+    protected Long memberId;
+    protected Long fromMemberId;
+    protected AlarmType alarmType;
+
+    public abstract Map<String, String> toMap();
+}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/ProductAlarmPayload.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/ProductAlarmPayload.java
@@ -1,0 +1,84 @@
+package freshtrash.freshtrashbackend.dto.request;
+
+import freshtrash.freshtrashbackend.entity.ChatRoom;
+import freshtrash.freshtrashbackend.entity.constants.AlarmType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductAlarmPayload extends BaseAlarmPayload {
+
+    @Override
+    public Map<String, String> toMap() {
+        Map<String, String> data = new HashMap<>();
+        data.put("productId", targetId.toString());
+        data.put("memberId", memberId.toString());
+        data.put("fromMemberId", fromMemberId.toString());
+        data.put("alarmType", alarmType.name());
+        return data;
+    }
+
+    /**
+     * 구매자에게 리뷰 요청 알림
+     */
+    public static BaseAlarmPayload ofRequestReview(String message, ChatRoom chatRoom, AlarmType alarmType) {
+        return ofProductDeal(message, chatRoom, alarmType)
+                .memberId(chatRoom.getSellerId())
+                .fromMemberId(chatRoom.getBuyerId())
+                .build();
+    }
+
+    /**
+     * 판매자가 올린 상품이 거래되었음을 채팅 요청한 구매자들 또는 판매자에게 알림
+     */
+    public static BaseAlarmPayload ofCompletedProductDeal(String message, ChatRoom chatRoom, AlarmType alarmType) {
+        return ofProductDeal(message, chatRoom, alarmType)
+                .memberId(chatRoom.getBuyerId())
+                .fromMemberId(chatRoom.getSellerId())
+                .build();
+    }
+
+    /**
+     * 예약을 취소하거나 요청할 때 상품의 판매 상태가 변경되었음을 알림
+     */
+    public static BaseAlarmPayload ofUpdatedSellStatus(String message, ChatRoom chatRoom, AlarmType alarmType) {
+        return ofProductDeal(message, chatRoom, alarmType)
+                .memberId(chatRoom.getBuyerId())
+                .fromMemberId(chatRoom.getSellerId())
+                .build();
+    }
+
+    /**
+     * 현재 사용자에의해 특정 사용자가 신고되었음을 알림
+     */
+    public static BaseAlarmPayload ofUserFlag(
+            String message, Long productId, Long targetMemberId, Long currentMemberId) {
+        return ProductAlarmPayload.builder()
+                .message(message)
+                .targetId(productId)
+                .memberId(targetMemberId)
+                .fromMemberId(currentMemberId)
+                .alarmType(AlarmType.FLAG)
+                .build();
+    }
+
+    private static ProductAlarmPayloadBuilder ofProductDeal(String message, ChatRoom chatRoom, AlarmType alarmType) {
+        return ProductAlarmPayload.builder()
+                .message(message)
+                .targetId(chatRoom.getProductId())
+                .alarmType(alarmType);
+    }
+
+    @Builder
+    private ProductAlarmPayload(String message, Long targetId, Long memberId, Long fromMemberId, AlarmType alarmType) {
+        this.message = message;
+        this.targetId = targetId;
+        this.memberId = memberId;
+        this.fromMemberId = fromMemberId;
+        this.alarmType = alarmType;
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Alarm.java
@@ -1,6 +1,6 @@
 package freshtrash.freshtrashbackend.entity;
 
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
 import freshtrash.freshtrashbackend.entity.audit.CreatedAt;
 import freshtrash.freshtrashbackend.entity.constants.AlarmType;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
@@ -61,12 +61,12 @@ public class Alarm extends CreatedAt {
         this.memberId = memberId;
     }
 
-    public static Alarm fromMessageRequest(AlarmPayload alarmPayload) {
+    public static Alarm fromAlarmPayload(BaseAlarmPayload baseAlarmPayload) {
         return Alarm.builder()
-                .message(alarmPayload.message())
-                .memberId(alarmPayload.memberId())
-                .alarmType(alarmPayload.alarmType())
-                .alarmArgs(AlarmArgs.of(alarmPayload.fromMemberId(), alarmPayload.targetId()))
+                .message(baseAlarmPayload.getMessage())
+                .memberId(baseAlarmPayload.getMemberId())
+                .alarmType(baseAlarmPayload.getAlarmType())
+                .alarmArgs(AlarmArgs.of(baseAlarmPayload.getFromMemberId(), baseAlarmPayload.getTargetId()))
                 .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
@@ -27,8 +27,9 @@ public class BiddingHistory extends CreatedAt {
     @Column(nullable = false)
     private int price; // 입찰 금액
 
+    @Setter
     @Column(nullable = false)
-    private boolean isSuccessBidding; // 낙찰 여부
+    private boolean isPay; // 결제 여부
 
     @ToString.Exclude
     @ManyToOne(optional = false, fetch = LAZY)

--- a/src/main/java/freshtrash/freshtrashbackend/exception/BiddingHistoryException.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/BiddingHistoryException.java
@@ -1,0 +1,15 @@
+package freshtrash.freshtrashbackend.exception;
+
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BiddingHistoryException extends CustomException {
+    public BiddingHistoryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BiddingHistoryException(ErrorCode errorCode, Exception causeException) {
+        super(errorCode, causeException);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
+++ b/src/main/java/freshtrash/freshtrashbackend/exception/constants/ErrorCode.java
@@ -53,7 +53,11 @@ public enum ErrorCode {
     INVALID_AUCTION_TIME(HttpStatus.BAD_REQUEST, "경매 시간이 잘못되었습니다."),
     WRITER_CANT_BIDDING(HttpStatus.BAD_REQUEST, "경매 등록 사용자는 입찰할 수 없습니다."),
     INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "요청 입찰가는 기존 입찰가보다 커야하고 최소 10원 단위의 금액을 입력해야합니다."),
-    CANT_BIDDING_TIME(HttpStatus.BAD_REQUEST, "지금은 경매 중이 아닙니다.");
+    CANT_BIDDING_TIME(HttpStatus.BAD_REQUEST, "지금은 경매 중이 아닙니다."),
+    FORBIDDEN_AUCTION_BID(HttpStatus.FORBIDDEN, "판매자는 경매를 입찰할 수 없습니다."),
+
+    // Bidding History
+    NOT_FOUND_BIDDING_HISTORY(HttpStatus.NOT_FOUND, "입찰 내역이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
@@ -1,13 +1,15 @@
 package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.Optional;
 
 @Transactional(propagation = Propagation.SUPPORTS)
 public interface BiddingHistoryRepository extends JpaRepository<BiddingHistory, Long> {
-    List<BiddingHistory> findAllByAuctionId(Long auctionId);
+    @EntityGraph(attributePaths = {"auction", "member"})
+    Optional<BiddingHistory> findFirstByAuctionIdAndMemberIdOrderByPriceDesc(Long auctionId, Long memberId);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -1,6 +1,6 @@
 package freshtrash.freshtrashbackend.service;
 
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
 import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.exception.AlarmException;
@@ -40,8 +40,8 @@ public class AlarmService {
     /**
      * 알람 저장
      */
-    public Alarm saveAlarm(AlarmPayload alarmPayload) {
-        return alarmRepository.save(Alarm.fromMessageRequest(alarmPayload));
+    public Alarm saveAlarm(BaseAlarmPayload baseAlarmPayload) {
+        return alarmRepository.save(Alarm.fromAlarmPayload(baseAlarmPayload));
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
@@ -1,0 +1,42 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import freshtrash.freshtrashbackend.exception.BiddingHistoryException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.repository.BiddingHistoryRepository;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BiddingHistoryService {
+    private final BiddingHistoryRepository biddingHistoryRepository;
+    private final AuctionPublisher auctionPublisher;
+
+    public void addBiddingHistory(Long auctionId, Long memberId, int price) {
+        biddingHistoryRepository.save(BiddingHistory.builder()
+                .auctionId(auctionId)
+                .memberId(memberId)
+                .price(price)
+                .build());
+    }
+
+    @Transactional
+    public void updateToCompletedPayAndNotify(Long auctionId, Long memberId) {
+        log.debug("auctionId {} 경매에 입찰한 memberId {} 유저가 입찰한 내역 중 가장 큰 금액으로 입찰한 내역 조회", auctionId, memberId);
+        BiddingHistory biddingHistory = getBiddingHistoryByAuctionIdAndMemberId(auctionId, memberId);
+        biddingHistory.setPay(true);
+        log.debug("결제한 유저와 판매자에게 결제 완료 알림 전송");
+        auctionPublisher.publishForCompletedPayAndRequestDelivery(biddingHistory);
+    }
+
+    private BiddingHistory getBiddingHistoryByAuctionIdAndMemberId(Long auctionId, Long memberId) {
+        return biddingHistoryRepository
+                .findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId)
+                .orElseThrow(() -> new BiddingHistoryException(ErrorCode.NOT_FOUND_BIDDING_HISTORY));
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelAuctionAlarm.java
@@ -24,12 +24,12 @@ public class CancelAuctionAlarm extends AuctionAlarmTemplate {
     @Override
     protected void publishEvent(Auction auction, Long bidMemberId) {
         log.debug("입찰자에게 경매 취소되었음을 알림");
-        this.producer.cancelAuction(auction, bidMemberId);
+        this.producer.publishToBiddersForCancelAuction(auction, bidMemberId);
     }
 
     @Override
     protected void publishEvent(Auction auction) {
         log.debug("구매자에게 경매 취소되었음을 알림");
-        this.producer.cancelAuction(auction);
+        this.producer.publishToSellerForCancelAuction(auction);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelBookingProductAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CancelBookingProductAlarm.java
@@ -30,7 +30,7 @@ public class CancelBookingProductAlarm extends ProductAlarmTemplate {
         this.chatRoomService
                 .getNotClosedChatRoomsByProductId(bookedChatRoom.getProductId())
                 .forEach(chatRoom -> {
-                    this.producer.updateSellStatus(chatRoom, message, AlarmType.TRANSACTION);
+                    this.producer.publishForUpdatedSellStatus(chatRoom, message, AlarmType.TRANSACTION);
                 });
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
@@ -23,13 +23,13 @@ public class CompleteBidAuctionAlarm extends AuctionAlarmTemplate {
     @Override
     public void publishEvent(Auction auction, Long bidMemberId) {
         log.debug("판매자에게 낙찰 알림, 구매자에게 결제 요청 알림");
-        this.producer.completeBid(auction, bidMemberId);
-        this.producer.requestPay(auction, bidMemberId);
+        this.producer.publishToSellerForCompletedAuction(auction, bidMemberId);
+        this.producer.publishToWonBidderForRequestPay(auction, bidMemberId);
     }
 
     @Override
     public void publishEvent(Auction auction) {
         log.debug("입찰자가 없음을 판매자에게 알림");
-        this.producer.notCompleteBid(auction);
+        this.producer.publishToSellerForNotExistBidders(auction);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteDealProductAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteDealProductAlarm.java
@@ -31,15 +31,15 @@ public class CompleteDealProductAlarm extends ProductAlarmTemplate {
     @Override
     public void publishEvent(ChatRoom closedChatRoom) {
         // 판매자, 구매자에게 알람 전송
-        this.producer.completeDeal(closedChatRoom);
-        log.debug("Send message to seller.");
-        this.producer.requestReview(closedChatRoom);
-        log.debug("Send message to buyer.");
+        log.debug("판매자에게 판매 완료 알림 전송");
+        this.producer.publishForCompletedProductDeal(closedChatRoom);
+        log.debug("구매자에게 리뷰 요청 알림 전송");
+        this.producer.publishToBuyerForRequestReview(closedChatRoom);
 
         // 그 밖의 채팅 요청한 사용자들에게 알람 전송
+        log.debug("채팅 요청했던 사용자들에게 판매 완료 알림 전송");
         chatRoomService
                 .getNotClosedChatRoomsByProductId(closedChatRoom.getProductId())
-                .forEach(this.producer::completeDeal);
-        log.debug("Send message to others.");
+                .forEach(this.producer::publishForCompletedProductDeal);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/RequestBookingProductAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/RequestBookingProductAlarm.java
@@ -30,7 +30,7 @@ public class RequestBookingProductAlarm extends ProductAlarmTemplate {
         chatRoomService
                 .getNotClosedChatRoomsByProductId(ongoingChatRoom.getProductId())
                 .forEach(chatRoom -> {
-                    this.producer.updateSellStatus(chatRoom, message, AlarmType.BOOKING_REQUEST);
+                    this.producer.publishForUpdatedSellStatus(chatRoom, message, AlarmType.BOOKING_REQUEST);
                 });
     }
 

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/ChatProducer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/ChatProducer.java
@@ -1,7 +1,7 @@
 package freshtrash.freshtrashbackend.service.producer;
 
 import freshtrash.freshtrashbackend.dto.events.AlarmEvent;
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.ProductAlarmPayload;
 import freshtrash.freshtrashbackend.service.producer.publisher.MQPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +24,6 @@ public class ChatProducer {
                 message);
         mqPublisher.publish(AlarmEvent.of(
                 PRODUCT_TRANSACTION_FLAG.getRoutingKey(),
-                AlarmPayload.ofUserFlag(message, productId, targetMemberId, currentMemberId)));
+                ProductAlarmPayload.ofUserFlag(message, productId, targetMemberId, currentMemberId)));
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/ProductDealProducer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/ProductDealProducer.java
@@ -1,7 +1,7 @@
 package freshtrash.freshtrashbackend.service.producer;
 
 import freshtrash.freshtrashbackend.dto.events.AlarmEvent;
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.ProductAlarmPayload;
 import freshtrash.freshtrashbackend.entity.ChatRoom;
 import freshtrash.freshtrashbackend.entity.constants.AlarmType;
 import freshtrash.freshtrashbackend.service.producer.publisher.MQPublisher;
@@ -18,23 +18,23 @@ import static freshtrash.freshtrashbackend.dto.constants.AlarmMessage.REQUEST_RE
 public class ProductDealProducer {
     private final MQPublisher mqPublisher;
 
-    public void completeDeal(ChatRoom chatRoom) {
+    public void publishForCompletedProductDeal(ChatRoom chatRoom) {
         mqPublisher.publish(AlarmEvent.of(
                 PRODUCT_TRANSACTION_COMPLETE.getRoutingKey(),
-                AlarmPayload.ofProductDealBySeller(
+                ProductAlarmPayload.ofCompletedProductDeal(
                         COMPLETED_SELL_MESSAGE.getMessage(), chatRoom, AlarmType.TRANSACTION)));
     }
 
-    public void requestReview(ChatRoom chatRoom) {
+    public void publishToBuyerForRequestReview(ChatRoom chatRoom) {
         mqPublisher.publish(AlarmEvent.of(
                 PRODUCT_TRANSACTION_COMPLETE.getRoutingKey(),
-                AlarmPayload.ofProductDealByBuyer(
+                ProductAlarmPayload.ofRequestReview(
                         REQUEST_REVIEW_MESSAGE.getMessage(), chatRoom, AlarmType.TRANSACTION)));
     }
 
-    public void updateSellStatus(ChatRoom chatRoom, String message, AlarmType alarmType) {
+    public void publishForUpdatedSellStatus(ChatRoom chatRoom, String message, AlarmType alarmType) {
         mqPublisher.publish(AlarmEvent.of(
                 PRODUCT_CHANGE_SELL_STATUS.getRoutingKey(),
-                AlarmPayload.ofProductDealBySeller(message, chatRoom, alarmType)));
+                ProductAlarmPayload.ofUpdatedSellStatus(message, chatRoom, alarmType)));
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -52,8 +52,8 @@ public class FixtureDto {
                 .build();
     }
 
-    public static AlarmPayload createAlarmPayload() {
-        return AlarmPayload.builder()
+    public static BaseAlarmPayload createAlarmPayload() {
+        return ProductAlarmPayload.builder()
                 .message("test message")
                 .targetId(1L)
                 .memberId(123L)

--- a/src/test/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumerTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumerTest.java
@@ -2,7 +2,8 @@ package freshtrash.freshtrashbackend.consumer;
 
 import com.rabbitmq.client.Channel;
 import freshtrash.freshtrashbackend.Fixture.FixtureDto;
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.ProductAlarmPayload;
 import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.repository.EmitterRepository;
 import freshtrash.freshtrashbackend.service.AlarmService;
@@ -43,17 +44,17 @@ class ProductAlarmConsumerTest {
     @DisplayName("알람 메시지 consume")
     void given_alarmPayload_when_listenMessage_then_saveAlarmAndSendAlarm() {
         // given
-        AlarmPayload alarmPayload = FixtureDto.createAlarmPayload();
-        Long memberId = alarmPayload.memberId();
-        Alarm alarm = Alarm.fromMessageRequest(alarmPayload);
+        BaseAlarmPayload baseAlarmPayload = FixtureDto.createAlarmPayload();
+        Long memberId = baseAlarmPayload.getMemberId();
+        Alarm alarm = Alarm.fromAlarmPayload(baseAlarmPayload);
         SseEmitter sseEmitter = new SseEmitter(TimeUnit.MINUTES.toMillis(30));
         Channel channel = mock(Channel.class);
         long deliveryTag = 3;
-        given(alarmService.saveAlarm(eq(alarmPayload))).willReturn(alarm);
+        given(alarmService.saveAlarm(eq(baseAlarmPayload))).willReturn(alarm);
         given(emitterRepository.findByMemberId(eq(memberId))).willReturn(Optional.of(sseEmitter));
         // whenxp
-        productAlarmConsumer.consumeProductDealMessage(channel, deliveryTag, alarmPayload);
-        ArgumentCaptor<AlarmPayload> alarmCaptor = ArgumentCaptor.forClass(AlarmPayload.class);
+        productAlarmConsumer.consumeProductDealMessage(channel, deliveryTag, baseAlarmPayload);
+        ArgumentCaptor<ProductAlarmPayload> alarmCaptor = ArgumentCaptor.forClass(ProductAlarmPayload.class);
         // then
         verify(alarmService, times(1)).saveAlarm(alarmCaptor.capture());
         verify(emitterRepository, times(1)).findByMemberId(eq(memberId));

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ProductLikeApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ProductLikeApiTest.java
@@ -7,7 +7,6 @@ import freshtrash.freshtrashbackend.controller.constants.LikeStatus;
 import freshtrash.freshtrashbackend.dto.response.ProductResponse;
 import freshtrash.freshtrashbackend.entity.constants.ProductCategory;
 import freshtrash.freshtrashbackend.service.ProductLikeService;
-import freshtrash.freshtrashbackend.service.ProductService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -66,7 +65,8 @@ class ProductLikeApiTest {
     @DisplayName("관심 폐기물 추가/삭제")
     @WithUserDetails(value = "testUser@gmail.com", setupBefore = TEST_EXECUTION)
     @CsvSource(value = {"LIKE", "UNLIKE"})
-    void given_likeStatusAndProductIdAndLoginUser_when_addOrDeleteProductLike_then_returnBoolean(LikeStatus likeStatus) throws Exception {
+    void given_likeStatusAndProductIdAndLoginUser_when_addOrDeleteProductLike_then_returnBoolean(LikeStatus likeStatus)
+            throws Exception {
         // given
         Long productId = 1L;
         Long memberId = 123L;
@@ -76,9 +76,10 @@ class ProductLikeApiTest {
             willDoNothing().given(productLikeService).deleteProductLike(memberId, productId);
         }
         // when
-        mvc.perform(post("/api/v1/products/" + productId + "/likes").queryParam("likeStatus", String.valueOf(likeStatus)))
+        mvc.perform(post("/api/v1/products/" + productId + "/likes")
+                        .queryParam("likeStatus", String.valueOf(likeStatus)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").value(likeStatus==LikeStatus.LIKE));
+                .andExpect(jsonPath("$.data").value(likeStatus == LikeStatus.LIKE));
         // then
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ProductReviewApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ProductReviewApiTest.java
@@ -37,7 +37,8 @@ class ProductReviewApiTest {
     @Test
     @DisplayName("폐기물 리뷰 작성")
     @WithUserDetails(value = "testUser@gmail.com", setupBefore = TEST_EXECUTION)
-    void given_reviewRequestAndProductIdAndLoginUser_when_addProductReview_then_returnReviewResponse() throws Exception {
+    void given_reviewRequestAndProductIdAndLoginUser_when_addProductReview_then_returnReviewResponse()
+            throws Exception {
         // given
         ReviewRequest reviewRequest = FixtureDto.createReviewRequest(4);
         Long productId = 1L;

--- a/src/test/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepositoryTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepositoryTest.java
@@ -1,0 +1,25 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Disabled
+@SpringBootTest
+class BiddingHistoryRepositoryTest {
+    @Autowired
+    private BiddingHistoryRepository biddingHistoryRepository;
+
+    @Test
+    void findByAuctionIdAndMemberId() {
+        Long auctionId = 2L, memberId = 1L;
+        BiddingHistory biddingHistory = biddingHistoryRepository
+                .findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId)
+                .get();
+        assertThat(biddingHistory.getPrice()).isEqualTo(2000);
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AlarmServiceTest.java
@@ -1,17 +1,12 @@
 package freshtrash.freshtrashbackend.service;
 
-import com.rabbitmq.client.Channel;
 import freshtrash.freshtrashbackend.Fixture.Fixture;
-import freshtrash.freshtrashbackend.Fixture.FixtureDto;
-import freshtrash.freshtrashbackend.dto.request.AlarmPayload;
 import freshtrash.freshtrashbackend.dto.response.AlarmResponse;
-import freshtrash.freshtrashbackend.entity.Alarm;
 import freshtrash.freshtrashbackend.repository.AlarmRepository;
 import freshtrash.freshtrashbackend.repository.EmitterRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,17 +15,13 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionEventServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionEventServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 
 import static org.mockito.BDDMockito.*;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 @ActiveProfiles("test")
@@ -51,15 +50,15 @@ class AuctionEventServiceTest {
     @DisplayName("경매가 취소되면 입찰자들에게 알림을 전송합니다.")
     @Test
     void given_auctionIdAndLoginUser_when_writerOrAdmin_then_deleteAuctionAndNotifyToBidUsers() {
-        //given
+        // given
         Long auctionId = 1L, memberId = 2L;
         UserRole userRole = UserRole.USER;
         Auction auction = Fixture.createAuction();
         willDoNothing().given(auctionService).checkIfWriterOrAdmin(auctionId, userRole, memberId);
         given(auctionService.getAuctionWithBiddingHistory(auctionId)).willReturn(auction);
         willDoNothing().given(cancelAuctionAlarm).sendAlarm(auction);
-        //when
+        // when
         auctionEventService.cancelAuction(auctionId, userRole, memberId);
-        //then
+        // then
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
@@ -9,7 +9,6 @@ import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import freshtrash.freshtrashbackend.entity.QAuction;
-import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.repository.AuctionRepository;
 import freshtrash.freshtrashbackend.repository.BiddingHistoryRepository;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/freshtrash/freshtrashbackend/service/BiddingHistoryServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/BiddingHistoryServiceTest.java
@@ -1,0 +1,47 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import freshtrash.freshtrashbackend.repository.BiddingHistoryRepository;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class BiddingHistoryServiceTest {
+
+    @InjectMocks
+    private BiddingHistoryService biddingHistoryService;
+
+    @Mock
+    private BiddingHistoryRepository biddingHistoryRepository;
+
+    @Mock
+    private AuctionPublisher auctionPublisher;
+
+    @Test
+    @DisplayName("결제 완료 후 낙찰된 입찰 내역의 결제 여부를 TRUE로 업데이트하고 판매자/구매자에게 알림 전송")
+    void given_auctionIdAndMemberId_when_completedPay_then_updateIsPayAndNotify() {
+        // given
+        Long auctionId = 2L, memberId = 1L;
+        BiddingHistory biddingHistory = Fixture.createBiddingHistory(auctionId, memberId, 1000);
+        given(biddingHistoryRepository.findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId))
+                .willReturn(Optional.of(biddingHistory));
+        willDoNothing().given(auctionPublisher).publishForCompletedPayAndRequestDelivery(biddingHistory);
+        // when
+        biddingHistoryService.updateToCompletedPayAndNotify(auctionId, memberId);
+        // then
+        then(biddingHistoryRepository).should().findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId);
+        then(auctionPublisher).should().publishForCompletedPayAndRequestDelivery(biddingHistory);
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/service/ProductDealServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/ProductDealServiceTest.java
@@ -25,7 +25,8 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

경매가 낙찰되고 구매자에게 결제 요청 알림이 가게됩니다. 구매자는 알림을 통해 결제를 진행하고, 완료되었을 경우 구매자가 입찰했던 입찰 내역(BiddingHostory)의 결제 여부를 true로 변경합니다.

이때 낙찰 여부를 나타내는 isSuccessBidding 속성을 isPay로 변경하여 결제 여부에 대한 정보로 바꾸어줍니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- 경매 결제관련 메시지를 전달하는 큐 추가
  - `queue.auction.pay`, `queue.auction.pay.dlq`

- BiddingHistory 엔티티 수정
  - `isSuccessBidding` -> `isPay`로 변경하여 결제 여부를 나타내는 속성으로 바꾸었습니다.

- 경매의 결제 완료 처리 기능 추가
  - 결제 완료 처리 API 추가
  - 입찰한 금액 중 가장 큰 금액의 입찰 내역을 조회하여 결제 여부(isPay)를 true로 변경합니다. 그리고 판매자/구매자에게 알림을 전송하는데, 판매자에게는 배송을 요청하는 메시지 내용을 추가해주었습니다.

- Consumer의 listener에 결제관련 큐를 추가해주고 수정한 메소드 네이밍 반영
  - AuctionAlarmConsumer, DeadLetterConsumer의 listener에 큐를 추가

### API 테스트 결과

![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/6c1a5762-e393-430e-8383-8d3edb80a31e)

![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/9bffde54-1d11-4a0a-a159-96ff5fcd3241)

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- AlarmPayload와 Publisher에서의 메소드 네이밍 수정
  - 메소드의 동작을 명시적으로 나타내기위해 각 메소드 네이밍을 수정해주었습니다.
  - 결제 완료 처리 후 판매자/구매자에게 알림을 전송하는데 사용할 메소드도 추가해주었습니다.
  - 추상 클래스 `BaseAlarmPayload`를 만들고 ProductAlarmPayload, AuctionAlarmPayload 이름으로 각각 구체 클래스를 구현하여 분리하였습니다. 추후 ProductAlarm 또는 AuctionAlarm 과 관련하여 추가적인 필드가 필요할 경우 데코레이터 패턴을 적용하여 추가해줄 수 있을 것이라 기대하고 있습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #176 