### PR TITLE
미결제된 낙찰 경매 알림

### DIFF
--- a/database/mariadb/initdb.d/create_table.sql
+++ b/database/mariadb/initdb.d/create_table.sql
@@ -163,6 +163,7 @@ CREATE TABLE `bidding_history`
     `auction_id` bigint                NOT NULL,
     `price`      integer               NOT NULL,
     `is_pay`     tinyint(1)            NOT NULL,
+    `success_bid_at` datetime,
     `created_at` datetime              NOT NULL,
     `deleted_at` datetime,
     PRIMARY KEY (`id`),

--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -190,8 +190,8 @@ values (1, 'test.png', 'title', 'content', 'CLOTHING', 'GOOD', 'ONGOING', 1000, 
         date_add(now(), interval 1 hour), now()),
        (4, 'test.png', 'title4', 'content4', 'SPORTS', 'GOOD', 'ONGOING', 3000, 5, now(), now(), now());
 
-insert into bidding_history(member_id, auction_id, price, is_pay, created_at)
-values (2, 1, 1000, true, now()),
-       (1, 2, 1000, false, now()),
-       (1, 2, 2000, false, now()),
-       (1, 3, 3000, true, now());
+insert into bidding_history(member_id, auction_id, price, is_pay, success_bid_at, created_at)
+values (2, 1, 1000, true, now(), now()),
+       (1, 2, 1000, false, null, now()),
+       (1, 2, 2000, false, null, now()),
+       (1, 3, 3000, false, now(), now());

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
@@ -17,7 +17,9 @@ public enum AlarmMessage {
     REQUEST_PAY_AUCTION_MESSAGE("경매 [%s]가 낙찰되었습니다. 24시간 이내에 결제바랍니다."),
     CANCEL_AUCTION_MESSAGE("경매 [%s]가 취소되었습니다."),
     COMPLETED_PAY_MESSAGE("경매 [%s] 상품 결제가 완료되었습니다."),
-    COMPLETED_PAY_AND_REQUEST_DELIVERY_MESSAGE("경매 [%s] 상품 결제가 완료되었습니다. %s 님에게 상품을 배송해주세요.");
+    COMPLETED_PAY_AND_REQUEST_DELIVERY_MESSAGE("경매 [%s] 상품 결제가 완료되었습니다. %s 님에게 상품을 배송해주세요."),
+    BUYER_NOT_PAID_MESSAGE("%s님이 경매 [%s] 상품을 24시간 이내에 결제하지않아 해당 경매 낙찰을 취소합니다."),
+    NOT_PAID_MESSAGE("경매 [%s] 상품을 24시간 이내에 결제하지않아 경매 낙찰을 취소합니다.");
 
     private final String message;
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionAlarmPayload.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionAlarmPayload.java
@@ -91,6 +91,23 @@ public class AuctionAlarmPayload extends BaseAlarmPayload {
                 .build();
     }
 
+    /**
+     * 24시간 내에 결제되지 않아 경매 낙찰이 취소되었음을 알림
+     */
+    public static BaseAlarmPayload ofNotPaidToSeller(String message, Auction auction, Long buyerId) {
+        return ofAuction(message, auction, AlarmType.NOT_PAY)
+                .memberId(auction.getMemberId())
+                .fromMemberId(buyerId)
+                .build();
+    }
+
+    /**
+     * 24시간 내에 결제되지 않아 경매 낙찰이 취소되었음을 알림
+     */
+    public static BaseAlarmPayload ofNotPaidToWonBidder(String message, Auction auction, Long buyerId) {
+        return ofAuction(message, auction, AlarmType.NOT_PAY).memberId(buyerId).build();
+    }
+
     private static AuctionAlarmPayloadBuilder ofAuction(String message, Auction auction, AlarmType alarmType) {
         return AuctionAlarmPayload.builder()
                 .message(message)

--- a/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/BiddingHistory.java
@@ -47,6 +47,9 @@ public class BiddingHistory extends CreatedAt {
     @Column(nullable = false)
     private Long auctionId;
 
+    @Setter
+    private LocalDateTime successBidAt; // 낙찰 일시
+
     private LocalDateTime deletedAt;
 
     @Builder

--- a/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/Member.java
@@ -22,6 +22,8 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @TypeDef(name = "json", typeClass = JsonType.class)
 public class Member extends AuditingAt {
+    public static final int USER_FLAG_LIMIT = 10; // 블랙리스트에 들어갈 유저 신고 횟수
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AuctionRepository.java
@@ -47,4 +47,7 @@ public interface AuctionRepository
 
     @Query(nativeQuery = true, value = "update auctions a set a.auction_status = 'CLOSE' where a.id = ?1")
     void closeAuctionById(Long id);
+
+    @Query(nativeQuery = true, value = "update auctions a set a.auction_status = 'CANCEL' where a.id = ?1")
+    void cancelAuctionById(Long auctionId);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
@@ -3,13 +3,21 @@ package freshtrash.freshtrashbackend.repository;
 import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Transactional(propagation = Propagation.SUPPORTS)
 public interface BiddingHistoryRepository extends JpaRepository<BiddingHistory, Long> {
     @EntityGraph(attributePaths = {"auction", "member"})
     Optional<BiddingHistory> findFirstByAuctionIdAndMemberIdOrderByPriceDesc(Long auctionId, Long memberId);
+
+    @Modifying
+    @Query("update BiddingHistory bh set bh.successBidAt = current_timestamp where bh.auctionId = ?1")
+    void updateSuccessBidAtByAuctionId(Long auctionId);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepository.java
@@ -20,4 +20,9 @@ public interface BiddingHistoryRepository extends JpaRepository<BiddingHistory, 
     @Modifying
     @Query("update BiddingHistory bh set bh.successBidAt = current_timestamp where bh.auctionId = ?1")
     void updateSuccessBidAtByAuctionId(Long auctionId);
+
+    @EntityGraph(attributePaths = {"auction", "member"})
+    @Query(
+            "select bh from BiddingHistory bh where bh.isPay = false and bh.successBidAt is not null and bh.successBidAt < ?1")
+    List<BiddingHistory> findAllNotPaidAnd24HoursAgo(LocalDateTime dateTime24HoursAgo);
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionEventService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionEventService.java
@@ -4,6 +4,7 @@ import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.entity.constants.UserRole;
 import freshtrash.freshtrashbackend.service.alarm.CancelAuctionAlarm;
 import freshtrash.freshtrashbackend.service.alarm.CompleteBidAuctionAlarm;
+import freshtrash.freshtrashbackend.service.alarm.NotPaidAuctionAlarm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,14 +17,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AuctionEventService {
     private final AuctionService auctionService;
+    private final BiddingHistoryService biddingHistoryService;
     private final CompleteBidAuctionAlarm completeBidAuctionAlarm;
     private final CancelAuctionAlarm cancelAuctionAlarm;
+    private final NotPaidAuctionAlarm notPaidAuctionAlarm;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void processCompletedAuctions() {
         List<Auction> auctions = auctionService.getEndedAuctions();
         // 입찰자 여부를 확인하고 입찰자가 없으면 구매자에게 알림, 있으면 판매자에게 알림
         auctions.forEach(completeBidAuctionAlarm::sendAlarm);
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void processNotPaidAuctions() {
+        // 낙찰되었지만 24시간 지난 입찰 내역을 조회 후 로직 수행
+        biddingHistoryService.getSuccessBiddingHistories().forEach(notPaidAuctionAlarm::sendAlarm);
     }
 
     public void cancelAuction(Long auctionId, UserRole userRole, Long memberId) {

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionService.java
@@ -100,6 +100,11 @@ public class AuctionService {
         auctionRepository.closeAuctionById(auctionId);
     }
 
+    public void cancelAuction(Long auctionId) {
+        log.debug("경매 판매 상태를 CANCEL로 변경");
+        auctionRepository.cancelAuctionById(auctionId);
+    }
+
     public List<Auction> getEndedAuctions() {
         log.debug("마감되었지만 AuctionStatus가 ONGOING인 경매 조회");
         return auctionRepository.findAllEndedAuctions();

--- a/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
@@ -10,6 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -23,6 +26,14 @@ public class BiddingHistoryService {
                 .memberId(memberId)
                 .price(price)
                 .build());
+    }
+
+    /**
+     * 낙찰되었지만 결제되지않은 입찰 내역 조회
+     */
+    public List<BiddingHistory> getSuccessBiddingHistories() {
+        return biddingHistoryRepository.findAllNotPaidAnd24HoursAgo(
+                LocalDateTime.now().minusDays(1));
     }
 
     @Transactional
@@ -40,5 +51,9 @@ public class BiddingHistoryService {
         return biddingHistoryRepository
                 .findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId)
                 .orElseThrow(() -> new BiddingHistoryException(ErrorCode.NOT_FOUND_BIDDING_HISTORY));
+    }
+
+    public void deleteBiddingHistory(Long biddingHistoryId) {
+        biddingHistoryRepository.deleteById(biddingHistoryId);
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
@@ -34,6 +34,10 @@ public class BiddingHistoryService {
         auctionPublisher.publishForCompletedPayAndRequestDelivery(biddingHistory);
     }
 
+    public void updateSuccessBidAt(Long auctionId) {
+        biddingHistoryRepository.updateSuccessBidAtByAuctionId(auctionId);
+    }
+
     private BiddingHistory getBiddingHistoryByAuctionIdAndMemberId(Long auctionId, Long memberId) {
         return biddingHistoryRepository
                 .findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId)

--- a/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/BiddingHistoryService.java
@@ -4,7 +4,7 @@ import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import freshtrash.freshtrashbackend.exception.BiddingHistoryException;
 import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
 import freshtrash.freshtrashbackend.repository.BiddingHistoryRepository;
-import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import freshtrash.freshtrashbackend.service.alarm.CompletePayAuctionAlarm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BiddingHistoryService {
     private final BiddingHistoryRepository biddingHistoryRepository;
-    private final AuctionPublisher auctionPublisher;
+    private final CompletePayAuctionAlarm completePayAuctionAlarm;
 
     public void addBiddingHistory(Long auctionId, Long memberId, int price) {
         biddingHistoryRepository.save(BiddingHistory.builder()
@@ -29,16 +29,14 @@ public class BiddingHistoryService {
     public void updateToCompletedPayAndNotify(Long auctionId, Long memberId) {
         log.debug("auctionId {} 경매에 입찰한 memberId {} 유저가 입찰한 내역 중 가장 큰 금액으로 입찰한 내역 조회", auctionId, memberId);
         BiddingHistory biddingHistory = getBiddingHistoryByAuctionIdAndMemberId(auctionId, memberId);
-        biddingHistory.setPay(true);
-        log.debug("결제한 유저와 판매자에게 결제 완료 알림 전송");
-        auctionPublisher.publishForCompletedPayAndRequestDelivery(biddingHistory);
+        completePayAuctionAlarm.sendAlarm(biddingHistory);
     }
 
     public void updateSuccessBidAt(Long auctionId) {
         biddingHistoryRepository.updateSuccessBidAtByAuctionId(auctionId);
     }
 
-    private BiddingHistory getBiddingHistoryByAuctionIdAndMemberId(Long auctionId, Long memberId) {
+    public BiddingHistory getBiddingHistoryByAuctionIdAndMemberId(Long auctionId, Long memberId) {
         return biddingHistoryRepository
                 .findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId)
                 .orElseThrow(() -> new BiddingHistoryException(ErrorCode.NOT_FOUND_BIDDING_HISTORY));

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompleteBidAuctionAlarm.java
@@ -2,22 +2,29 @@ package freshtrash.freshtrashbackend.service.alarm;
 
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.service.AuctionService;
+import freshtrash.freshtrashbackend.service.BiddingHistoryService;
 import freshtrash.freshtrashbackend.service.alarm.template.AuctionAlarmTemplate;
 import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
 public class CompleteBidAuctionAlarm extends AuctionAlarmTemplate {
+    private final BiddingHistoryService biddingHistoryService;
 
-    public CompleteBidAuctionAlarm(AuctionService auctionService, AuctionPublisher producer) {
+    public CompleteBidAuctionAlarm(
+            AuctionService auctionService, AuctionPublisher producer, BiddingHistoryService biddingHistoryService) {
         super(auctionService, producer);
+        this.biddingHistoryService = biddingHistoryService;
     }
 
+    @Transactional
     @Override
     public void update(Long auctionId) {
         this.auctionService.closeAuction(auctionId);
+        this.biddingHistoryService.updateSuccessBidAt(auctionId);
     }
 
     @Override

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompletePayAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/CompletePayAuctionAlarm.java
@@ -1,0 +1,28 @@
+package freshtrash.freshtrashbackend.service.alarm;
+
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import freshtrash.freshtrashbackend.service.alarm.template.BiddingHistoryAlarmTemplate;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CompletePayAuctionAlarm extends BiddingHistoryAlarmTemplate {
+
+    public CompletePayAuctionAlarm(AuctionPublisher producer) {
+        super(producer);
+    }
+
+    @Override
+    public void update(BiddingHistory biddingHistory) {
+        log.debug("결제 여부를 true로 업데이트");
+        biddingHistory.setPay(true);
+    }
+
+    @Override
+    public void publishEvent(BiddingHistory biddingHistory) {
+        log.debug("결제한 유저와 판매자에게 결제 완료 알림 전송");
+        this.producer.publishForCompletedPayAndRequestDelivery(biddingHistory);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/NotPaidAuctionAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/NotPaidAuctionAlarm.java
@@ -1,0 +1,48 @@
+package freshtrash.freshtrashbackend.service.alarm;
+
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import freshtrash.freshtrashbackend.entity.Member;
+import freshtrash.freshtrashbackend.service.AuctionService;
+import freshtrash.freshtrashbackend.service.BiddingHistoryService;
+import freshtrash.freshtrashbackend.service.MemberService;
+import freshtrash.freshtrashbackend.service.alarm.template.BiddingHistoryAlarmTemplate;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+public class NotPaidAuctionAlarm extends BiddingHistoryAlarmTemplate {
+    private final MemberService memberService;
+    private final AuctionService auctionService;
+    private final BiddingHistoryService biddingHistoryService;
+
+    public NotPaidAuctionAlarm(
+            AuctionPublisher producer,
+            MemberService memberService,
+            AuctionService auctionService,
+            BiddingHistoryService biddingHistoryService) {
+        super(producer);
+        this.memberService = memberService;
+        this.auctionService = auctionService;
+        this.biddingHistoryService = biddingHistoryService;
+    }
+
+    @Transactional
+    @Override
+    public void update(BiddingHistory biddingHistory) {
+        log.debug("flagCount + 1");
+        this.memberService.updateFlagCount(biddingHistory.getMemberId(), Member.USER_FLAG_LIMIT);
+        log.debug("경매 취소 -> AuctionStatus = CANCEL");
+        this.auctionService.cancelAuction(biddingHistory.getAuctionId());
+        log.debug("입찰 내역 삭제");
+        // 추후 다음 순위의 입찰자에게 기회를 주도록 프로세스를 추가할 수 있음
+        biddingHistoryService.deleteBiddingHistory(biddingHistory.getId());
+    }
+
+    @Override
+    public void publishEvent(BiddingHistory biddingHistory) {
+        this.producer.publishForNotPaid(biddingHistory);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/UserFlagChatAlarm.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.service.alarm;
 
+import freshtrash.freshtrashbackend.entity.Member;
 import freshtrash.freshtrashbackend.service.MemberService;
 import freshtrash.freshtrashbackend.service.alarm.template.ChatAlarmTemplate;
 import freshtrash.freshtrashbackend.service.producer.ChatProducer;
@@ -13,8 +14,6 @@ import static freshtrash.freshtrashbackend.dto.constants.AlarmMessage.FLAG_MESSA
 @Component
 public class UserFlagChatAlarm extends ChatAlarmTemplate {
 
-    private static final int FLAG_LIMIT = 10;
-
     public UserFlagChatAlarm(MemberService memberService, ChatProducer producer) {
         super(memberService, producer);
     }
@@ -25,7 +24,9 @@ public class UserFlagChatAlarm extends ChatAlarmTemplate {
     @Override
     public int update(Long targetMemberId) {
         log.debug("유저 신고 횟수 + 1 업데이트...");
-        return this.memberService.updateFlagCount(targetMemberId, FLAG_LIMIT).flagCount();
+        return this.memberService
+                .updateFlagCount(targetMemberId, Member.USER_FLAG_LIMIT)
+                .flagCount();
     }
 
     @Override
@@ -36,7 +37,7 @@ public class UserFlagChatAlarm extends ChatAlarmTemplate {
     }
 
     private String generateMessage(int flagCount) {
-        return flagCount >= FLAG_LIMIT
+        return flagCount >= Member.USER_FLAG_LIMIT
                 ? EXCEED_FLAG_MESSAGE.getMessage()
                 : String.format(FLAG_MESSAGE.getMessage(), flagCount);
     }

--- a/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/BiddingHistoryAlarmTemplate.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/alarm/template/BiddingHistoryAlarmTemplate.java
@@ -1,0 +1,21 @@
+package freshtrash.freshtrashbackend.service.alarm.template;
+
+import freshtrash.freshtrashbackend.entity.BiddingHistory;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class BiddingHistoryAlarmTemplate {
+    protected final AuctionPublisher producer;
+
+    public final void sendAlarm(BiddingHistory biddingHistory) {
+        update(biddingHistory);
+        publishEvent(biddingHistory);
+    }
+
+    protected abstract void update(BiddingHistory biddingHistory);
+
+    protected abstract void publishEvent(BiddingHistory biddingHistory);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
@@ -77,4 +77,27 @@ public class AuctionPublisher {
                         biddingHistory.getAuction(),
                         biddingHistory.getMemberId())));
     }
+
+    public void publishForNotPaid(BiddingHistory biddingHistory) {
+        String auctionTitle = biddingHistory.getAuction().getTitle();
+        // 판매자에게 전송
+        mqPublisher.publish(AlarmEvent.of(
+                AUCTION_PAY.getRoutingKey(),
+                AuctionAlarmPayload.ofNotPaidToSeller(
+                        String.format(
+                                BUYER_NOT_PAID_MESSAGE.getMessage(),
+                                biddingHistory.getMember().getNickname(),
+                                auctionTitle),
+                        biddingHistory.getAuction(),
+                        biddingHistory.getMemberId())));
+        // 낙찰자에게 전송
+        mqPublisher.publish(AlarmEvent.of(
+                AUCTION_PAY.getRoutingKey(),
+                AuctionAlarmPayload.ofNotPaidToWonBidder(
+                        String.format(
+                                NOT_PAID_MESSAGE.getMessage(),
+                                auctionTitle),
+                        biddingHistory.getAuction(),
+                        biddingHistory.getMemberId())));
+    }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
@@ -2,6 +2,7 @@ package freshtrash.freshtrashbackend.service.producer;
 
 import freshtrash.freshtrashbackend.dto.events.AlarmEvent;
 import freshtrash.freshtrashbackend.dto.request.AuctionAlarmPayload;
+import freshtrash.freshtrashbackend.dto.request.BaseAlarmPayload;
 import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import freshtrash.freshtrashbackend.service.producer.publisher.MQPublisher;
@@ -19,85 +20,71 @@ public class AuctionPublisher {
     private final MQPublisher mqPublisher;
 
     public void publishToSellerForNotExistBidders(Auction auction) {
-        mqPublisher.publish(AlarmEvent.of(
-                AUCTION_BID_COMPLETE.getRoutingKey(),
-                AuctionAlarmPayload.ofNotExistBidders(
-                        String.format(NOT_COMPLETED_AUCTION_MESSAGE.getMessage(), auction.getTitle()), auction)));
+        String message = String.format(NOT_COMPLETED_AUCTION_MESSAGE.getMessage(), auction.getTitle());
+        publishAlarm(AUCTION_BID_COMPLETE.getRoutingKey(), AuctionAlarmPayload.ofNotExistBidders(message, auction));
     }
 
     public void publishToSellerForCompletedAuction(Auction auction, Long bidMemberId) {
-        mqPublisher.publish(AlarmEvent.of(
+        String message = String.format(COMPLETE_BID_AUCTION_MESSAGE.getMessage(), auction.getTitle());
+        publishAlarm(
                 AUCTION_BID_COMPLETE.getRoutingKey(),
-                AuctionAlarmPayload.ofCompletedAuction(
-                        String.format(COMPLETE_BID_AUCTION_MESSAGE.getMessage(), auction.getTitle()),
-                        auction,
-                        bidMemberId)));
+                AuctionAlarmPayload.ofCompletedAuction(message, auction, bidMemberId));
     }
 
     public void publishToWonBidderForRequestPay(Auction auction, Long bidMemberId) {
-        mqPublisher.publish(AlarmEvent.of(
-                AUCTION_BID_COMPLETE.getRoutingKey(),
-                AuctionAlarmPayload.ofRequestPay(
-                        String.format(REQUEST_PAY_AUCTION_MESSAGE.getMessage(), auction.getTitle()),
-                        auction,
-                        bidMemberId)));
+        String message = String.format(REQUEST_PAY_AUCTION_MESSAGE.getMessage(), auction.getTitle());
+        publishAlarm(
+                AUCTION_BID_COMPLETE.getRoutingKey(), AuctionAlarmPayload.ofRequestPay(message, auction, bidMemberId));
     }
 
     public void publishToBiddersForCancelAuction(Auction auction, Long bidMemberId) {
-        mqPublisher.publish(AlarmEvent.of(
+        String message = String.format(CANCEL_AUCTION_MESSAGE.getMessage(), auction.getTitle());
+        publishAlarm(
                 CANCEL_AUCTION.getRoutingKey(),
-                AuctionAlarmPayload.ofCancelAuctionToBidders(
-                        String.format(CANCEL_AUCTION_MESSAGE.getMessage(), auction.getTitle()), auction, bidMemberId)));
+                AuctionAlarmPayload.ofCancelAuctionToBidders(message, auction, bidMemberId));
     }
 
     public void publishToSellerForCancelAuction(Auction auction) {
-        mqPublisher.publish(AlarmEvent.of(
-                CANCEL_AUCTION.getRoutingKey(),
-                AuctionAlarmPayload.ofCancelAuctionToSeller(
-                        String.format(CANCEL_AUCTION_MESSAGE.getMessage(), auction.getTitle()), auction)));
+        String message = String.format(CANCEL_AUCTION_MESSAGE.getMessage(), auction.getTitle());
+        publishAlarm(CANCEL_AUCTION.getRoutingKey(), AuctionAlarmPayload.ofCancelAuctionToSeller(message, auction));
     }
 
     public void publishForCompletedPayAndRequestDelivery(BiddingHistory biddingHistory) {
         String auctionTitle = biddingHistory.getAuction().getTitle();
+        String bidderNickname = biddingHistory.getMember().getNickname();
+        String bidderMessage = String.format(COMPLETED_PAY_MESSAGE.getMessage(), auctionTitle);
+        String sellerMassage =
+                String.format(COMPLETED_PAY_AND_REQUEST_DELIVERY_MESSAGE.getMessage(), auctionTitle, bidderNickname);
         // 낙찰자에게 전송
-        mqPublisher.publish(AlarmEvent.of(
+        publishAlarm(
                 AUCTION_PAY.getRoutingKey(),
                 AuctionAlarmPayload.ofCompletedPayToWonBidder(
-                        String.format(COMPLETED_PAY_MESSAGE.getMessage(), auctionTitle),
-                        biddingHistory.getAuction(),
-                        biddingHistory.getMemberId())));
+                        bidderMessage, biddingHistory.getAuction(), biddingHistory.getMemberId()));
         // 판매자에게 전송
-        mqPublisher.publish(AlarmEvent.of(
+        publishAlarm(
                 AUCTION_PAY.getRoutingKey(),
                 AuctionAlarmPayload.ofCompletedPayAndRequestDeliveryToSeller(
-                        String.format(
-                                COMPLETED_PAY_AND_REQUEST_DELIVERY_MESSAGE.getMessage(),
-                                auctionTitle,
-                                biddingHistory.getMember().getNickname()),
-                        biddingHistory.getAuction(),
-                        biddingHistory.getMemberId())));
+                        sellerMassage, biddingHistory.getAuction(), biddingHistory.getMemberId()));
     }
 
     public void publishForNotPaid(BiddingHistory biddingHistory) {
         String auctionTitle = biddingHistory.getAuction().getTitle();
+        String buyerNickname = biddingHistory.getMember().getNickname();
+        String sellerMessage = String.format(BUYER_NOT_PAID_MESSAGE.getMessage(), buyerNickname, auctionTitle);
+        String bidderMessage = String.format(NOT_PAID_MESSAGE.getMessage(), auctionTitle);
         // 판매자에게 전송
-        mqPublisher.publish(AlarmEvent.of(
+        publishAlarm(
                 AUCTION_PAY.getRoutingKey(),
                 AuctionAlarmPayload.ofNotPaidToSeller(
-                        String.format(
-                                BUYER_NOT_PAID_MESSAGE.getMessage(),
-                                biddingHistory.getMember().getNickname(),
-                                auctionTitle),
-                        biddingHistory.getAuction(),
-                        biddingHistory.getMemberId())));
+                        sellerMessage, biddingHistory.getAuction(), biddingHistory.getMemberId()));
         // 낙찰자에게 전송
-        mqPublisher.publish(AlarmEvent.of(
+        publishAlarm(
                 AUCTION_PAY.getRoutingKey(),
                 AuctionAlarmPayload.ofNotPaidToWonBidder(
-                        String.format(
-                                NOT_PAID_MESSAGE.getMessage(),
-                                auctionTitle),
-                        biddingHistory.getAuction(),
-                        biddingHistory.getMemberId())));
+                        bidderMessage, biddingHistory.getAuction(), biddingHistory.getMemberId()));
+    }
+
+    private void publishAlarm(String routingKey, BaseAlarmPayload payload) {
+        mqPublisher.publish(AlarmEvent.of(routingKey, payload));
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/controller/ProductReviewApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/ProductReviewApiTest.java
@@ -52,7 +52,7 @@ class ProductReviewApiTest {
                         .content(objectMapper.writeValueAsString(reviewRequest)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.memberId").value(memberId))
-                .andExpect(jsonPath("$.targetId").value(productId))
+                .andExpect(jsonPath("$.productId").value(productId))
                 .andExpect(jsonPath("$.rating").value(reviewRequest.rate()));
         // then
     }

--- a/src/test/java/freshtrash/freshtrashbackend/integration/NotPaidAuctionIntegrationTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/integration/NotPaidAuctionIntegrationTest.java
@@ -1,0 +1,28 @@
+package freshtrash.freshtrashbackend.integration;
+
+import freshtrash.freshtrashbackend.config.TestSecurityConfig;
+import freshtrash.freshtrashbackend.service.AuctionEventService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Slf4j
+@Disabled
+@ActiveProfiles("integration_test")
+@SpringBootTest
+@Import(TestSecurityConfig.class)
+public class NotPaidAuctionIntegrationTest {
+    @Autowired
+    private AuctionEventService auctionEventService;
+
+    @Test
+    @DisplayName("매일 0시에 낙찰되었지만 24시간 지난 입찰 내역을 조회하여 결제가 안되었으면 경매를 취소하고 알림 전송한다.")
+    void processNotPaidAuctions() {
+        auctionEventService.processNotPaidAuctions();
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepositoryTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/repository/BiddingHistoryRepositoryTest.java
@@ -2,9 +2,13 @@ package freshtrash.freshtrashbackend.repository;
 
 import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,5 +25,12 @@ class BiddingHistoryRepositoryTest {
                 .findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId)
                 .get();
         assertThat(biddingHistory.getPrice()).isEqualTo(2000);
+    }
+
+    @Test
+    void findAllNotPaidAnd24HoursAgo() {
+        List<BiddingHistory> biddingHistories = biddingHistoryRepository.findAllNotPaidAnd24HoursAgo(
+                LocalDateTime.now().plusDays(1));
+        assertThat(biddingHistories.size()).isEqualTo(1);
     }
 }

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionServiceTest.java
@@ -10,7 +10,6 @@ import freshtrash.freshtrashbackend.entity.Auction;
 import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import freshtrash.freshtrashbackend.entity.QAuction;
 import freshtrash.freshtrashbackend.repository.AuctionRepository;
-import freshtrash.freshtrashbackend.repository.BiddingHistoryRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +44,7 @@ class AuctionServiceTest {
     private LocalFileService fileService;
 
     @Mock
-    private BiddingHistoryRepository biddingHistoryRepository;
+    private BiddingHistoryService biddingHistoryService;
 
     @DisplayName("경매 추가")
     @Test
@@ -105,9 +104,8 @@ class AuctionServiceTest {
         Long auctionId = 1L, memberId = 3L;
         int biddingPrice = 10000;
         Auction auction = Fixture.createAuction();
-        BiddingHistory biddingHistory = Fixture.createBiddingHistory(auctionId, memberId, biddingPrice);
         given(auctionRepository.findById(eq(auctionId))).willReturn(Optional.of(auction));
-        given(biddingHistoryRepository.save(any(BiddingHistory.class))).willReturn(biddingHistory);
+        willDoNothing().given(biddingHistoryService).addBiddingHistory(auctionId, memberId, biddingPrice);
         // when
         auctionService.requestBidding(auctionId, biddingPrice, memberId);
         // then

--- a/src/test/java/freshtrash/freshtrashbackend/service/BiddingHistoryServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/BiddingHistoryServiceTest.java
@@ -3,6 +3,7 @@ package freshtrash.freshtrashbackend.service;
 import freshtrash.freshtrashbackend.Fixture.Fixture;
 import freshtrash.freshtrashbackend.entity.BiddingHistory;
 import freshtrash.freshtrashbackend.repository.BiddingHistoryRepository;
+import freshtrash.freshtrashbackend.service.alarm.CompletePayAuctionAlarm;
 import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class BiddingHistoryServiceTest {
     private BiddingHistoryRepository biddingHistoryRepository;
 
     @Mock
-    private AuctionPublisher auctionPublisher;
+    private CompletePayAuctionAlarm completePayAuctionAlarm;
 
     @Test
     @DisplayName("결제 완료 후 낙찰된 입찰 내역의 결제 여부를 TRUE로 업데이트하고 판매자/구매자에게 알림 전송")
@@ -37,11 +38,11 @@ class BiddingHistoryServiceTest {
         BiddingHistory biddingHistory = Fixture.createBiddingHistory(auctionId, memberId, 1000);
         given(biddingHistoryRepository.findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId))
                 .willReturn(Optional.of(biddingHistory));
-        willDoNothing().given(auctionPublisher).publishForCompletedPayAndRequestDelivery(biddingHistory);
+        willDoNothing().given(completePayAuctionAlarm).sendAlarm(biddingHistory);
         // when
         biddingHistoryService.updateToCompletedPayAndNotify(auctionId, memberId);
         // then
         then(biddingHistoryRepository).should().findFirstByAuctionIdAndMemberIdOrderByPriceDesc(auctionId, memberId);
-        then(auctionPublisher).should().publishForCompletedPayAndRequestDelivery(biddingHistory);
+        then(completePayAuctionAlarm).should().sendAlarm(biddingHistory);
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

경매가 낙찰되고 구매자에게 결제 요청을 했지만 24시간이 지나고 결제를 하지 않는다면, 해당 경매를 취소합니다. 이때 구매하려고했던 사용자에게는 경고의 의미로 flagCount + 1 해줍니다. 그리고 판매자/구매자에게 결제되지 않아 경매가 취소되었음을 알려주도록 합니다.

결제되지 않은 경매는 임의로 매일 0시에 확인합니다. 그리고 입찰 내역에서 낙찰 여부와 일시를 확인하기위해 BiddingHistory에 낙찰 일시를 나타내는 속성을 추가 (successBidAt) 해주어야합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- BiddingHistory에 낙찰 일시를 의미하는 successBidAt 속성추가 
  - 낙찰되지 않았을 경우 null 값을 가지고 낙찰 되었을 경우 낙찰된 일시가 저장됨

- 낙찰된 후 24시간 이내에 결제되지 않은 경매 처리 추가 
  1. 낙찰되었지만 24시간 지난 입찰 내역을 조회
  2. 입찰자의 flagCount + 1
  3. 경매는 취소 처리 (AuctionStatus = CANCEL)
  4. 해당 입찰 내역을 삭제 
    - 입찰 내역을 삭제해줌으로써 추후 다음 순위의 입찰자에게 기회를 주도록 프로세스를 추가할 수 있을 것이라 기대하고 있습니다.

- 통합 테스트를 통해 정상적으로 동작하는 것을 확인했습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 전역 변수 FLAG_LIMIT를 Member 엔티티 안으로 이동 
  - FLAG_LIMIT은 블랙리스트에 들어갈 유저 신고(경고) 횟수를 의미하므로 Member 엔티티에 전역 변수로 위치 선정 
  - FLAG_LIMIT -> USER_FLAG_LIMIT 네이밀 수정

- 경매 낙찰 처리 시 successBidAt 업데이트 로직 추가 
  - 마감된 경매를 CLOSE 상태로 업데이트 한 후 최종 입찰 내역의 입찰 일시를 업데이트해주도록 반영

- 결제 완료 처리 후 알람 전송하는 로직에 Template Method 패턴 적용 
  - biddingHistory의 isPay 속성을 true로 업데이트하고 알림을 전송하는 로직을 template method로 구현

- AuctionPublisher의 반복 코드 분리
  - 메소드가 계속 추가됨에따라 반복되는 코드가 많아져 따로 분리했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #178 
