### PR TITLE
상품 수령 후 알림

### DIFF
--- a/database/mariadb/initdb.d/create_table.sql
+++ b/database/mariadb/initdb.d/create_table.sql
@@ -158,16 +158,30 @@ CREATE TABLE `auctions`
 
 CREATE TABLE `bidding_history`
 (
-    `id`         bigint AUTO_INCREMENT NOT NULL,
-    `member_id`  bigint                NOT NULL,
-    `auction_id` bigint                NOT NULL,
-    `price`      integer               NOT NULL,
-    `is_pay`     tinyint(1)            NOT NULL,
+    `id`             bigint AUTO_INCREMENT NOT NULL,
+    `member_id`      bigint                NOT NULL,
+    `auction_id`     bigint                NOT NULL,
+    `price`          integer               NOT NULL,
+    `is_pay`         tinyint(1)            NOT NULL,
     `success_bid_at` datetime,
-    `created_at` datetime              NOT NULL,
-    `deleted_at` datetime,
+    `created_at`     datetime              NOT NULL,
+    `deleted_at`     datetime,
     PRIMARY KEY (`id`),
     foreign key (`member_id`) references members (id) on delete cascade,
     foreign key (`auction_id`) references auctions (id) on delete cascade
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='입찰 내역';
+
+CREATE TABLE `auction_reviews`
+(
+    `id`         bigint AUTO_INCREMENT NOT NULL,
+    `member_id`  bigint                NOT NULL,
+    `auction_id` bigint                NOT NULL,
+    `rating`     integer               NOT NULL,
+    `content`    text,
+    `created_at` datetime              NOT NULL,
+    PRIMARY KEY (`id`),
+    foreign key (`member_id`) references members (id) on delete cascade,
+    foreign key (`auction_id`) references auctions (id) on delete cascade
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='경매 낙찰 리뷰';

--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -188,10 +188,17 @@ values (1, 'test.png', 'title', 'content', 'CLOTHING', 'GOOD', 'ONGOING', 1000, 
         date_add(now(), interval 1 hour), now()),
        (3, 'test.png', 'title3', 'content3', 'SPORTS', 'GOOD', 'CLOSE', 3000, 5, now(),
         date_add(now(), interval 1 hour), now()),
-       (4, 'test.png', 'title4', 'content4', 'SPORTS', 'GOOD', 'ONGOING', 3000, 5, now(), now(), now());
+       (4, 'test.png', 'title4', 'content4', 'SPORTS', 'GOOD', 'ONGOING', 3000, 5, now(), now(), now()),
+       (5, 'test.png', 'title5', 'content5', 'CLOTHING', 'BEST', 'ONGOING', 3000, 5, now(), now(), now());
 
 insert into bidding_history(member_id, auction_id, price, is_pay, success_bid_at, created_at)
 values (2, 1, 1000, true, now(), now()),
        (1, 2, 1000, false, null, now()),
        (1, 2, 2000, false, null, now()),
        (1, 3, 3000, false, now(), now());
+
+insert into auction_reviews(member_id, auction_id, rating, content, created_at)
+values (1, 2, 3, 'good', now()),
+       (2, 3, 2, '.', now()),
+       (3, 4, 1, '좋음', now()),
+       (4, 1, 5, '', now());

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/BindingConfig.java
@@ -50,6 +50,11 @@ public class BindingConfig {
         return createBinding(auctionPayQueue, topicExchange, AUCTION_PAY.getRoutingKey());
     }
 
+    @Bean
+    Binding reviewBinding(Queue reviewQueue, TopicExchange topicExchange) {
+        return createBinding(reviewQueue, topicExchange, REVIEW.getRoutingKey());
+    }
+
     /**
      * DLQ Binding
      */
@@ -86,6 +91,11 @@ public class BindingConfig {
     @Bean
     Binding dlqAuctionPayBinding(Queue dlqAuctionPayQueue, TopicExchange dlqExchange) {
         return createBinding(dlqAuctionPayQueue, dlqExchange, DLQ_AUCTION_PAY.getRoutingKey());
+    }
+
+    @Bean
+    Binding dlqReviewBinding(Queue dlqReviewQueue, TopicExchange dlqExchange) {
+        return createBinding(dlqReviewQueue, dlqExchange, DLQ_REVIEW.getRoutingKey());
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueConfig.java
@@ -53,6 +53,11 @@ public class QueueConfig {
         return createQueueWithDLQ(AUCTION_PAY, DLQ_AUCTION_PAY);
     }
 
+    @Bean
+    Queue reviewQueue() {
+        return createQueueWithDLQ(REVIEW, DLQ_REVIEW);
+    }
+
     /**
      * DLQ
      */
@@ -89,6 +94,11 @@ public class QueueConfig {
     @Bean
     Queue dlqAuctionPayQueue() {
         return createQueue(DLQ_AUCTION_PAY);
+    }
+
+    @Bean
+    Queue dlqReviewQueue() {
+        return createQueue(DLQ_REVIEW);
     }
 
     /**

--- a/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/config/rabbitmq/QueueType.java
@@ -14,6 +14,7 @@ public enum QueueType {
     AUCTION_BID_COMPLETE("queue.auction.complete", "auction.bid.complete"),
     CANCEL_AUCTION("queue.auction.cancel", "auction.cancel"),
     AUCTION_PAY("queue.auction.pay", "auction.pay"),
+    REVIEW("queue.review", "product.review"),
 
     // DLQ
     DLQ_PRODUCT_TRANSACTION_COMPLETE("queue.product.complete.dlq", "product.productDeal.complete"),
@@ -23,6 +24,7 @@ public enum QueueType {
     DLQ_AUCTION_BID_COMPLETE("queue.auction.complete.dlq", "auction.bid.complete"),
     DLQ_CANCEL_AUCTION("queue.auction.cancel.dlq", "auction.cancel"),
     DLQ_AUCTION_PAY("queue.auction.pay.dlq", "auction.pay"),
+    DLQ_REVIEW("queue.review.dlq", "product.review"),
 
     // Parking Lot
     PRODUCT_PARKING_LOT("queue.product.parking-lot", "product.#"),

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/DeadLetterConsumer.java
@@ -27,7 +27,8 @@ public class DeadLetterConsumer {
                 "#{dlqChatQueue.name}",
                 "#{dlqAuctionCompleteQueue.name}",
                 "#{dlqCancelAuctionQueue.name}",
-                "#{dlqAuctionPayQueue}"
+                "#{dlqAuctionPayQueue.name}",
+                "#{dlqReviewQueue.name}"
             })
     public void handleFailedProductDealMessage(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, Message message) {

--- a/src/main/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumer.java
+++ b/src/main/java/freshtrash/freshtrashbackend/consumer/ProductAlarmConsumer.java
@@ -25,7 +25,12 @@ public class ProductAlarmConsumer {
      */
     @ManualAcknowledge
     @RabbitListener(
-            queues = {"#{productCompleteQueue.name}", "#{productFlagQueue.name}", "#{productChangeStatusQueue.name}"})
+            queues = {
+                "#{productCompleteQueue.name}",
+                "#{productFlagQueue.name}",
+                "#{productChangeStatusQueue.name}",
+                "#{reviewQueue.name}"
+            })
     public void consumeProductDealMessage(
             Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag, @Payload BaseAlarmPayload alarmPayload) {
         log.debug("receive complete productDeal message: {}", alarmPayload);

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionReviewApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionReviewApi.java
@@ -1,0 +1,34 @@
+package freshtrash.freshtrashbackend.controller;
+
+import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
+import freshtrash.freshtrashbackend.dto.response.ReviewResponse;
+import freshtrash.freshtrashbackend.dto.security.MemberPrincipal;
+import freshtrash.freshtrashbackend.service.AuctionReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auctions")
+public class AuctionReviewApi {
+    private final AuctionReviewService auctionReviewService;
+
+    /**
+     * 경매 낙찰 상품 리뷰 작성
+     */
+    @PostMapping("/{auctionId}/reviews")
+    private ResponseEntity<ReviewResponse> addAuctionReview(
+            @RequestBody @Valid ReviewRequest reviewRequest,
+            @PathVariable Long auctionId,
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+
+        ReviewResponse reviewResponse = ReviewResponse.fromEntity(
+                auctionReviewService.insertAuctionReview(reviewRequest, auctionId, memberPrincipal.id()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(reviewResponse);
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/controller/AuctionReviewApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/AuctionReviewApi.java
@@ -22,7 +22,7 @@ public class AuctionReviewApi {
      * 경매 낙찰 상품 리뷰 작성
      */
     @PostMapping("/{auctionId}/reviews")
-    private ResponseEntity<ReviewResponse> addAuctionReview(
+    public ResponseEntity<ReviewResponse> addAuctionReview(
             @RequestBody @Valid ReviewRequest reviewRequest,
             @PathVariable Long auctionId,
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {

--- a/src/main/java/freshtrash/freshtrashbackend/controller/ProductReviewApi.java
+++ b/src/main/java/freshtrash/freshtrashbackend/controller/ProductReviewApi.java
@@ -22,7 +22,7 @@ public class ProductReviewApi {
      * 폐기물 리뷰 작성
      */
     @PostMapping("/{productId}/reviews")
-    private ResponseEntity<ReviewResponse> addProductReview(
+    public ResponseEntity<ReviewResponse> addProductReview(
             @RequestBody @Valid ReviewRequest reviewRequest,
             @PathVariable Long productId,
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {

--- a/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/constants/AlarmMessage.java
@@ -19,7 +19,8 @@ public enum AlarmMessage {
     COMPLETED_PAY_MESSAGE("경매 [%s] 상품 결제가 완료되었습니다."),
     COMPLETED_PAY_AND_REQUEST_DELIVERY_MESSAGE("경매 [%s] 상품 결제가 완료되었습니다. %s 님에게 상품을 배송해주세요."),
     BUYER_NOT_PAID_MESSAGE("%s님이 경매 [%s] 상품을 24시간 이내에 결제하지않아 해당 경매 낙찰을 취소합니다."),
-    NOT_PAID_MESSAGE("경매 [%s] 상품을 24시간 이내에 결제하지않아 경매 낙찰을 취소합니다.");
+    NOT_PAID_MESSAGE("경매 [%s] 상품을 24시간 이내에 결제하지않아 경매 낙찰을 취소합니다."),
+    REVIEW_FROM_BUYER_MESSAGE("작성된 상품 리뷰가 있습니다.");
 
     private final String message;
 }

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionAlarmPayload.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/AuctionAlarmPayload.java
@@ -102,6 +102,16 @@ public class AuctionAlarmPayload extends BaseAlarmPayload {
     }
 
     /**
+     * 리뷰 작성 & 상품 수령 알림
+     */
+    public static BaseAlarmPayload ofReview(String message, Auction auction, Long buyerId) {
+        return ofAuction(message, auction, AlarmType.RECEIVE)
+                .memberId(auction.getMemberId())
+                .fromMemberId(buyerId)
+                .build();
+    }
+
+    /**
      * 24시간 내에 결제되지 않아 경매 낙찰이 취소되었음을 알림
      */
     public static BaseAlarmPayload ofNotPaidToWonBidder(String message, Auction auction, Long buyerId) {

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/ReviewRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/ReviewRequest.java
@@ -2,4 +2,4 @@ package freshtrash.freshtrashbackend.dto.request;
 
 import javax.validation.constraints.NotNull;
 
-public record ReviewRequest(@NotNull Integer rate) {}
+public record ReviewRequest(@NotNull Integer rate, String content) {}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/request/ReviewRequest.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/request/ReviewRequest.java
@@ -1,5 +1,6 @@
 package freshtrash.freshtrashbackend.dto.request;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
 
-public record ReviewRequest(@NotNull Integer rate, String content) {}
+public record ReviewRequest(@NotNull @Max(5) Integer rate, String content) {}

--- a/src/main/java/freshtrash/freshtrashbackend/dto/response/ReviewResponse.java
+++ b/src/main/java/freshtrash/freshtrashbackend/dto/response/ReviewResponse.java
@@ -1,15 +1,26 @@
 package freshtrash.freshtrashbackend.dto.response;
 
+import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
+import freshtrash.freshtrashbackend.entity.AuctionReview;
 import freshtrash.freshtrashbackend.entity.ProductReview;
 import lombok.Builder;
 
 @Builder
-public record ReviewResponse(Long memberId, Long productId, Integer rating) {
+public record ReviewResponse(Long memberId, Long productId, Integer rating, String content) {
     public static ReviewResponse fromEntity(ProductReview productReview) {
         return ReviewResponse.builder()
                 .memberId(productReview.getMemberId())
                 .productId(productReview.getProductId())
                 .rating(productReview.getRating())
+                .build();
+    }
+
+    public static ReviewResponse fromEntity(AuctionReview auctionReview) {
+        return ReviewResponse.builder()
+                .memberId(auctionReview.getMemberId())
+                .productId(auctionReview.getAuctionId())
+                .rating(auctionReview.getRating())
+                .content(auctionReview.getContent())
                 .build();
     }
 }

--- a/src/main/java/freshtrash/freshtrashbackend/entity/AuctionReview.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/AuctionReview.java
@@ -1,0 +1,61 @@
+package freshtrash.freshtrashbackend.entity;
+
+import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
+import freshtrash.freshtrashbackend.entity.audit.CreatedAt;
+import lombok.*;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Getter
+@Entity
+@ToString(callSuper = true)
+@Table(name = "auction_reviews")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuctionReview extends CreatedAt {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @ToString.Exclude
+    @ManyToOne(optional = false, fetch = LAZY)
+    @JoinColumn(name = "memberId", insertable = false, updatable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @ToString.Exclude
+    @OneToOne(optional = false, fetch = LAZY)
+    @JoinColumn(name = "auctionId", insertable = false, updatable = false)
+    private Auction auction;
+
+    @Column(nullable = false)
+    private Long auctionId;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(columnDefinition = "text")
+    private String content;
+
+    @Builder
+    public AuctionReview(Long memberId, Long auctionId, int rating, String content) {
+        this.memberId = memberId;
+        this.auctionId = auctionId;
+        this.rating = rating;
+        this.content = content;
+    }
+
+    public static AuctionReview fromRequest(ReviewRequest reviewRequest, Long auctionId, Long memberId) {
+        return AuctionReview.builder()
+                .content(reviewRequest.content())
+                .rating(reviewRequest.rate())
+                .memberId(memberId)
+                .auctionId(auctionId)
+                .build();
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/repository/AuctionReviewRepository.java
+++ b/src/main/java/freshtrash/freshtrashbackend/repository/AuctionReviewRepository.java
@@ -1,0 +1,8 @@
+package freshtrash.freshtrashbackend.repository;
+
+import freshtrash.freshtrashbackend.entity.AuctionReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuctionReviewRepository extends JpaRepository<AuctionReview, Long> {
+    boolean existsByAuctionId(Long auctionId);
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/AuctionReviewService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AuctionReviewService.java
@@ -1,0 +1,38 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.AuctionReview;
+import freshtrash.freshtrashbackend.exception.ReviewException;
+import freshtrash.freshtrashbackend.exception.constants.ErrorCode;
+import freshtrash.freshtrashbackend.repository.AuctionReviewRepository;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuctionReviewService {
+    private final AuctionReviewRepository auctionReviewRepository;
+    private final AuctionService auctionService;
+    private final AuctionPublisher auctionPublisher;
+
+    @Transactional
+    public AuctionReview insertAuctionReview(ReviewRequest reviewRequest, Long auctionId, Long memberId) {
+        // 이미 리뷰가 등록되어있는지 확인
+        if (auctionReviewRepository.existsByAuctionId(auctionId)) {
+            throw new ReviewException(ErrorCode.ALREADY_EXISTS_REVIEW);
+        }
+        log.debug("경매 리뷰 저장");
+        AuctionReview auctionReview = AuctionReview.fromRequest(reviewRequest, auctionId, memberId);
+        auctionReview = auctionReviewRepository.save(auctionReview);
+
+        log.debug("판매자에게 리뷰 알림 전송");
+        Auction auction = auctionService.getAuction(auctionId);
+        auctionPublisher.publishToSellerForReview(auction, memberId);
+        return auctionReview;
+    }
+}

--- a/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/producer/AuctionPublisher.java
@@ -84,6 +84,12 @@ public class AuctionPublisher {
                         bidderMessage, biddingHistory.getAuction(), biddingHistory.getMemberId()));
     }
 
+    public void publishToSellerForReview(Auction auction, Long buyerId) {
+        publishAlarm(
+                REVIEW.getRoutingKey(),
+                AuctionAlarmPayload.ofReview(REVIEW_FROM_BUYER_MESSAGE.getMessage(), auction, buyerId));
+    }
+
     private void publishAlarm(String routingKey, BaseAlarmPayload payload) {
         mqPublisher.publish(AlarmEvent.of(routingKey, payload));
     }

--- a/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
+++ b/src/test/java/freshtrash/freshtrashbackend/Fixture/FixtureDto.java
@@ -67,7 +67,11 @@ public class FixtureDto {
     }
 
     public static ReviewRequest createReviewRequest(int rate) {
-        return new ReviewRequest(rate);
+        return new ReviewRequest(rate, "");
+    }
+
+    public static ReviewRequest createReviewRequest(int rate, String content) {
+        return new ReviewRequest(rate, content);
     }
 
     public static AuctionRequest createAuctionRequest() {

--- a/src/test/java/freshtrash/freshtrashbackend/controller/AuctionReviewApiTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/controller/AuctionReviewApiTest.java
@@ -1,0 +1,57 @@
+package freshtrash.freshtrashbackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import freshtrash.freshtrashbackend.Fixture.FixtureDto;
+import freshtrash.freshtrashbackend.config.TestSecurityConfig;
+import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
+import freshtrash.freshtrashbackend.entity.AuctionReview;
+import freshtrash.freshtrashbackend.service.AuctionReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(AuctionReviewApi.class)
+@Import(TestSecurityConfig.class)
+class AuctionReviewApiTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuctionReviewService auctionReviewService;
+
+    @Test
+    @DisplayName("구매자는 결제한 낙찰 상품을 수령받고 리뷰를 작성한다.")
+    @WithUserDetails(value = "testUser@gmail.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    void given_reviewRequestAndAuctionIdAndLoginUser_when_then_insertReview() throws Exception {
+        // given
+        Long auctionId = 2L, memberId = 123L;
+        ReviewRequest reviewRequest = FixtureDto.createReviewRequest(3, "content");
+        AuctionReview auctionReview = AuctionReview.fromRequest(reviewRequest, auctionId, memberId);
+        given(auctionReviewService.insertAuctionReview(reviewRequest, auctionId, memberId)).willReturn(auctionReview);
+        // when
+        mvc.perform(post("/api/v1/auctions/" + auctionId + "/reviews")
+                        .content(objectMapper.writeValueAsString(reviewRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.rating").value(reviewRequest.rate()))
+                .andExpect(jsonPath("$.content").value(reviewRequest.content()));
+        // then
+    }
+}

--- a/src/test/java/freshtrash/freshtrashbackend/service/AuctionReviewServiceTest.java
+++ b/src/test/java/freshtrash/freshtrashbackend/service/AuctionReviewServiceTest.java
@@ -1,0 +1,58 @@
+package freshtrash.freshtrashbackend.service;
+
+import freshtrash.freshtrashbackend.Fixture.Fixture;
+import freshtrash.freshtrashbackend.Fixture.FixtureDto;
+import freshtrash.freshtrashbackend.dto.request.ReviewRequest;
+import freshtrash.freshtrashbackend.entity.Auction;
+import freshtrash.freshtrashbackend.entity.AuctionReview;
+import freshtrash.freshtrashbackend.repository.AuctionReviewRepository;
+import freshtrash.freshtrashbackend.service.producer.AuctionPublisher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class AuctionReviewServiceTest {
+    @InjectMocks
+    private AuctionReviewService auctionReviewService;
+
+    @Mock
+    private AuctionReviewRepository auctionReviewRepository;
+
+    @Mock
+    private AuctionService auctionService;
+
+    @Mock
+    private AuctionPublisher auctionPublisher;
+
+    @Test
+    @DisplayName("이미 리뷰가 등록되어있는지 확인 후 저장하고 판매자에게 알림을 전송한다.")
+    void given_reviewRequestAndAuctionIdAndMemberId_when_notWroteReview_then_insertReviewAndNotify() {
+        // given
+        Long auctionId = 2L, memberId = 123L;
+        ReviewRequest reviewRequest = FixtureDto.createReviewRequest(3, "content");
+        AuctionReview auctionReview = AuctionReview.fromRequest(reviewRequest, auctionId, memberId);
+        Auction auction = Fixture.createAuction();
+        ReflectionTestUtils.setField(auctionReview, "auction", auction);
+        given(auctionReviewRepository.existsByAuctionId(auctionId)).willReturn(false);
+        given(auctionReviewRepository.save(any(AuctionReview.class))).willReturn(auctionReview);
+        given(auctionService.getAuction(auctionId)).willReturn(auction);
+        willDoNothing().given(auctionPublisher).publishToSellerForReview(auctionReview.getAuction(), memberId);
+        // when
+        AuctionReview savedAuctionReview = auctionReviewService.insertAuctionReview(reviewRequest, auctionId, memberId);
+        // then
+        assertThat(savedAuctionReview.getContent()).isEqualTo(reviewRequest.content());
+        assertThat(savedAuctionReview.getRating()).isEqualTo(reviewRequest.rate());
+    }
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제

구매자가 낙찰된 상품을 결제하고 판매자로부터 수령도 완료했을 경우 구매자는 상품을 정상적으로 수령했다는 의미로 리뷰를 작성해야합니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항

- AuctionReview 엔티티와 레포지토리 추가 
  - 레포지토리에 auctionId로 존재하는지 확인하는 쿼리 메소드 추가

- 리뷰관련 메시지를 전달받는 큐 추가 
  - Consumer에 추가한 큐를 등록

![image](https://github.com/fresh-trash-project/fresh-trash-backend/assets/61103343/28d9915b-bac4-44ca-97d7-cf43fa0d6942)

- 경매 리뷰 작성 API 구현 
  - 경매 리뷰 작성 요청을 받고 처리하는 비지니스 로직 구현 
  - 이미 리뷰를 작성했었는지 확인하는 방어 로직을 추가 
  - 리뷰를 DB에 저장하고 판매자에게 리뷰 작성 알림을 전송

- 단위 테스트 코드 작성

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 없음

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #180 
