### PR TITLE
클라이언트로 전송하는 알람 eventName 변경

### DIFF
--- a/database/mariadb/initdb.d/insert_data.sql
+++ b/database/mariadb/initdb.d/insert_data.sql
@@ -183,13 +183,22 @@ values (1, 'CHAT', json_object('fromMemberId', 2, 'targetId', 1), '거래 완료
 insert into auctions(member_id, file_name, title, content, product_category, product_status, auction_status, final_bid,
                      view_count, started_at, ended_at, created_at)
 values (1, 'test.png', 'title', 'content', 'CLOTHING', 'GOOD', 'ONGOING', 1000, 1, now(),
-        date_add(now(), interval 1 hour), now()),
+        date_add(now(), interval 1 month), now()),
        (2, 'test.png', 'title2', 'content2', 'HEALTH', 'GOOD', 'ONGOING', 1000, 3, now(),
-        date_add(now(), interval 1 hour), now()),
+        date_add(now(), interval 1 month), now()),
        (3, 'test.png', 'title3', 'content3', 'SPORTS', 'GOOD', 'CLOSE', 3000, 5, now(),
-        date_add(now(), interval 1 hour), now()),
-       (4, 'test.png', 'title4', 'content4', 'SPORTS', 'GOOD', 'ONGOING', 3000, 5, now(), now(), now()),
-       (5, 'test.png', 'title5', 'content5', 'CLOTHING', 'BEST', 'ONGOING', 3000, 5, now(), now(), now());
+        date_add(now(), interval 1 month), now()),
+       (4, 'test.png', 'title4', 'content4', 'SPORTS', 'GOOD', 'ONGOING', 3000, 6, now(), now(), now()),
+       (5, 'test.png', 'title5', 'content5', 'CLOTHING', 'BEST', 'ONGOING', 3000, 7, now(),
+        date_add(now(), interval 1 month), now()),
+       (1, 'test.png', 'title6', 'content6', 'CLOTHING', 'GOOD', 'ONGOING', 4000, 8, now(),
+        date_add(now(), interval 1 month), now()),
+       (2, 'test.png', 'title7', 'content7', 'CLOTHING', 'BEST', 'ONGOING', 5000, 9, now(),
+        date_add(now(), interval 1 month), now()),
+       (3, 'test.png', 'title8', 'content8', 'CLOTHING', 'GOOD', 'ONGOING', 6000, 10, now(),
+        date_add(now(), interval 1 month), now()),
+       (4, 'test.png', 'title9', 'content9', 'CLOTHING', 'GOOD', 'ONGOING', 7000, 11, now(),
+        date_add(now(), interval 1 month), now());
 
 insert into bidding_history(member_id, auction_id, price, is_pay, success_bid_at, created_at)
 values (2, 1, 1000, true, now(), now()),

--- a/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
+++ b/src/main/java/freshtrash/freshtrashbackend/entity/constants/AlarmType.java
@@ -1,12 +1,19 @@
 package freshtrash.freshtrashbackend.entity.constants;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum AlarmType {
-    TRANSACTION, // 거래 상태 변경 시 알림
-    BOOKING_REQUEST, // 예약 요청 알림
-    BIDDING, // 낙찰 알림
-    CANCEL, // 경매 취소 알림
-    PAY, // 결제 완료 알림
-    RECEIVE, // 상품 수령 알림
-    NOT_PAY, // 미결제 알림
-    FLAG // 사용자 신고 알림
+    TRANSACTION("product_status"), // 거래 상태 변경 시 알림
+    BOOKING_REQUEST("product_status"), // 예약 요청 알림
+    BIDDING("auction_status"), // 낙찰 알림
+    CANCEL("auction_status"), // 경매 취소 알림
+    RECEIVE("auction_status"), // 상품 수령 알림
+    PAY("pay_status"), // 결제 완료 알림
+    NOT_PAY("pay_status"), // 미결제 알림
+    FLAG("flag"); // 사용자 신고 알림
+
+    private final String eventName;
 }

--- a/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
+++ b/src/main/java/freshtrash/freshtrashbackend/service/AlarmService.java
@@ -105,7 +105,7 @@ public class AlarmService {
                             try {
                                 sseEmitter.send(SseEmitter.event()
                                         .id(String.valueOf(alarmResponse.id()))
-                                        .name(alarmResponse.alarmType().name())
+                                        .name(alarmResponse.alarmType().getEventName())
                                         .data(alarmResponse));
                             } catch (IOException | IllegalStateException e) {
                                 emitterRepository.deleteByMemberId(memberId);


### PR DESCRIPTION

## 🔍️ 이 PR을 통해 해결하려는 문제

프론트의 요청에 따라 알람 name을 AlarmType 그대로 지정하여 전송하던 것을 다음과 같이 변경하도록 합니다.

product_status(TRANSACTION, BOOKING_REQUEST) = 거래 상태 변경 시 알림

auction_status(BIDDING, CANCEL, RECEIVE) = 경매 상태 변경 시 알림

pay_status(PAY, NOT_PAY) = 결제 상태 변경 시 알림

flag = 사용자 신고 알림

## ✨ 이 PR에서 핵심적으로 변경된 사항
- SSE 알림 전송에 지정되는 eventName을 AlarmType 속성에 추가하여 product_status, auction_status, pay_status, falg로 나누었습니다.

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분

- 경매 임의 데이터를 추가했습니다.

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 1일 이내에 진행해 주세요.

## Issue Tags
- Closed: #184 
